### PR TITLE
Fixed SubprocVecEnv close.

### DIFF
--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -15,6 +15,7 @@ New Features:
 
 Bug Fixes:
 ^^^^^^^^^^
+- Fixed a bug in the ``close()`` method of ``SubprocVecEnv``, causing wrappers further down in the wrapper stack to not be closed. (@NeoExtended)
 
 Deprecations:
 ^^^^^^^^^^^^^

--- a/stable_baselines3/common/vec_env/subproc_vec_env.py
+++ b/stable_baselines3/common/vec_env/subproc_vec_env.py
@@ -29,6 +29,7 @@ def _worker(remote, parent_remote, env_fn_wrapper):
             elif cmd == 'render':
                 remote.send(env.render(data))
             elif cmd == 'close':
+                env.close()
                 remote.close()
                 break
             elif cmd == 'get_spaces':


### PR DESCRIPTION
Updated changelog.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes the close method of SubprocVecEnv to also close its remote environments. (see SB 2 issue 898)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->
- [x] I have raised an issue to propose this change ([required](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) for new features and bug fixes)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [ ] I have checked the codestyle using `make lint`
- [ ] I have ensured `make pytest` and `make type` both pass.

<!--- This Template is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->
