### PR TITLE
Fix ortho init when `bias=False` with custom policy

### DIFF
--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -31,6 +31,7 @@ Bug Fixes:
 - Fixed a bug in the ``close()`` method of ``SubprocVecEnv``, causing wrappers further down in the wrapper stack to not be closed. (@NeoExtended)
 - Fix target for updating q values in SAC: the entropy term was not conditioned by terminals states
 - Use ``cloudpickle.load`` instead of ``pickle.load`` in ``CloudpickleWrapper``. (@shwang)
+- Fixed a bug when use "bias=False" linear layer in custom features extractor for common policies
 
 Deprecations:
 ^^^^^^^^^^^^^

--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -31,7 +31,7 @@ Bug Fixes:
 - Fixed a bug in the ``close()`` method of ``SubprocVecEnv``, causing wrappers further down in the wrapper stack to not be closed. (@NeoExtended)
 - Fix target for updating q values in SAC: the entropy term was not conditioned by terminals states
 - Use ``cloudpickle.load`` instead of ``pickle.load`` in ``CloudpickleWrapper``. (@shwang)
-- Fixed a bug when use "bias=False" linear layer in custom features extractor for common policies
+- Fixed a bug with orthogonal initialization when `bias=False` in custom policy (@rk37)
 
 Deprecations:
 ^^^^^^^^^^^^^
@@ -357,4 +357,4 @@ And all the contributors:
 @Miffyli @dwiel @miguelrass @qxcv @jaberkow @eavelardev @ruifeng96150 @pedrohbtp @srivatsankrishnan @evilsocket
 @MarvineGothic @jdossgollin @SyllogismRXS @rusu24edward @jbulow @Antymon @seheevic @justinkterry @edbeeching
 @flodorner @KuKuXia @NeoExtended @PartiallyTyped @mmcenta @richardwu @kinalmehta @rolandgvc @tkelestemur @mloo3
-@tirafesi @blurLake @koulakis @joeljosephjin @shwang
+@tirafesi @blurLake @koulakis @joeljosephjin @shwang @rk37

--- a/stable_baselines3/common/policies.py
+++ b/stable_baselines3/common/policies.py
@@ -188,7 +188,8 @@ class BasePolicy(BaseModel):
         """
         if isinstance(module, (nn.Linear, nn.Conv2d)):
             nn.init.orthogonal_(module.weight, gain=gain)
-            module.bias.data.fill_(0.0)
+            if module.bias is not None:
+                module.bias.data.fill_(0.0)
 
     @abstractmethod
     def _predict(self, observation: th.Tensor, deterministic: bool = False) -> th.Tensor:


### PR DESCRIPTION
## Changes
1. Add module.bias none check before initialization at `common.policies.BasePolicy.init_weights()` .
1. Updated changelog.

## Motivation and Context
* [x]  I have raised an issue to propose this change ([required](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) for new features and bug fixes)

Closes #124

## Types of changes
* [x]  Bug fix (non-breaking change which fixes an issue)
* [ ]  New feature (non-breaking change which adds functionality)
* [ ]  Breaking change (fix or feature that would cause existing functionality to change)
* [ ]  Documentation (update in the documentation)

## Checklist:
* [x]  I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**)
* [x]  I have updated the changelog accordingly (**required**).
* [ ]  My change requires a change to the documentation.
* [ ]  I have updated the tests accordingly (_required for a bug fix or a new feature_).
* [ ]  I have updated the documentation accordingly.
* [x]  I have reformatted the code using `make format` (**required**)
* [x]  I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
* [x]  I have ensured `make pytest` and `make type` both pass. (**required**)