### PR TITLE
Remove "device" argument from policies

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,7 +52,7 @@ with open(version_file, "r") as file_handler:
 # -- Project information -----------------------------------------------------
 
 project = "Stable Baselines3"
-copyright = "2020, Stable Baselines3"
+copyright = "2020, Stable Baselines3"  # noqa: A001
 author = "Stable Baselines3 Contributors"
 
 # The short X.Y version

--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -24,6 +24,7 @@ Others:
 ^^^^^^^
 - Improve typing coverage of the ``VecEnv``
 - Removed ``AlreadySteppingError`` and ``NotSteppingError`` that were not used
+- Removed ``device`` keyword argument of policies; use ``policy.to(device)`` instead.
 
 Documentation:
 ^^^^^^^^^^^^^^

--- a/stable_baselines3/common/off_policy_algorithm.py
+++ b/stable_baselines3/common/off_policy_algorithm.py
@@ -141,7 +141,6 @@ class OffPolicyAlgorithm(BaseAlgorithm):
         # Update policy keyword arguments
         if sde_support:
             self.policy_kwargs["use_sde"] = self.use_sde
-        self.policy_kwargs["device"] = self.device
         # For gSDE only
         self.use_sde_at_warmup = use_sde_at_warmup
 

--- a/stable_baselines3/common/on_policy_algorithm.py
+++ b/stable_baselines3/common/on_policy_algorithm.py
@@ -116,7 +116,6 @@ class OnPolicyAlgorithm(BaseAlgorithm):
             self.action_space,
             self.lr_schedule,
             use_sde=self.use_sde,
-            device=self.device,
             **self.policy_kwargs  # pytype:disable=not-instantiable
         )
         self.policy = self.policy.to(self.device)

--- a/stable_baselines3/common/policies.py
+++ b/stable_baselines3/common/policies.py
@@ -34,7 +34,6 @@ class BaseModel(nn.Module, ABC):
 
     :param observation_space: (gym.spaces.Space) The observation space of the environment
     :param action_space: (gym.spaces.Space) The action space of the environment
-    :param device: (Union[th.device, str]) Device on which the code should run.
     :param features_extractor_class: (Type[BaseFeaturesExtractor]) Features extractor to use.
     :param features_extractor_kwargs: (Optional[Dict[str, Any]]) Keyword arguments
         to pass to the feature extractor.
@@ -52,7 +51,6 @@ class BaseModel(nn.Module, ABC):
         self,
         observation_space: gym.spaces.Space,
         action_space: gym.spaces.Space,
-        device: Union[th.device, str] = "auto",
         features_extractor_class: Type[BaseFeaturesExtractor] = FlattenExtractor,
         features_extractor_kwargs: Optional[Dict[str, Any]] = None,
         features_extractor: Optional[nn.Module] = None,
@@ -70,7 +68,6 @@ class BaseModel(nn.Module, ABC):
 
         self.observation_space = observation_space
         self.action_space = action_space
-        self.device = get_device(device)
         self.features_extractor = features_extractor
         self.normalize_images = normalize_images
 
@@ -111,6 +108,16 @@ class BaseModel(nn.Module, ABC):
             # features_extractor=self.features_extractor
             normalize_images=self.normalize_images,
         )
+
+    @property
+    def device(self) -> th.device:
+        """Infer which device this policy lives on by inspecting its parameters.
+        If it has no parameters, the 'auto' device is used as a fallback.
+
+        :return: (th.device)"""
+        for param in self.parameters():
+            return param.device
+        return get_device("auto")
 
     def save(self, path: str) -> None:
         """
@@ -300,7 +307,6 @@ class ActorCriticPolicy(BasePolicy):
     :param action_space: (gym.spaces.Space) Action space
     :param lr_schedule: (Callable) Learning rate schedule (could be constant)
     :param net_arch: ([int or dict]) The specification of the policy and value networks.
-    :param device: (str or th.device) Device on which the code should run.
     :param activation_fn: (Type[nn.Module]) Activation function
     :param ortho_init: (bool) Whether to use or not orthogonal initialization
     :param use_sde: (bool) Whether to use State Dependent Exploration or not
@@ -332,7 +338,6 @@ class ActorCriticPolicy(BasePolicy):
         action_space: gym.spaces.Space,
         lr_schedule: Callable[[float], float],
         net_arch: Optional[List[Union[int, Dict[str, List[int]]]]] = None,
-        device: Union[th.device, str] = "auto",
         activation_fn: Type[nn.Module] = nn.Tanh,
         ortho_init: bool = True,
         use_sde: bool = False,
@@ -357,7 +362,6 @@ class ActorCriticPolicy(BasePolicy):
         super(ActorCriticPolicy, self).__init__(
             observation_space,
             action_space,
-            device,
             features_extractor_class,
             features_extractor_kwargs,
             optimizer_class=optimizer_class,
@@ -445,9 +449,7 @@ class ActorCriticPolicy(BasePolicy):
         # Note: If net_arch is None and some features extractor is used,
         #       net_arch here is an empty list and mlp_extractor does not
         #       really contain any layers (acts like an identity module).
-        self.mlp_extractor = MlpExtractor(
-            self.features_dim, net_arch=self.net_arch, activation_fn=self.activation_fn, device=self.device
-        )
+        self.mlp_extractor = MlpExtractor(self.features_dim, net_arch=self.net_arch, activation_fn=self.activation_fn)
 
         latent_dim_pi = self.mlp_extractor.latent_dim_pi
 
@@ -594,7 +596,6 @@ class ActorCriticCnnPolicy(ActorCriticPolicy):
     :param action_space: (gym.spaces.Space) Action space
     :param lr_schedule: (Callable) Learning rate schedule (could be constant)
     :param net_arch: ([int or dict]) The specification of the policy and value networks.
-    :param device: (str or th.device) Device on which the code should run.
     :param activation_fn: (Type[nn.Module]) Activation function
     :param ortho_init: (bool) Whether to use or not orthogonal initialization
     :param use_sde: (bool) Whether to use State Dependent Exploration or not
@@ -626,7 +627,6 @@ class ActorCriticCnnPolicy(ActorCriticPolicy):
         action_space: gym.spaces.Space,
         lr_schedule: Callable,
         net_arch: Optional[List[Union[int, Dict[str, List[int]]]]] = None,
-        device: Union[th.device, str] = "auto",
         activation_fn: Type[nn.Module] = nn.Tanh,
         ortho_init: bool = True,
         use_sde: bool = False,
@@ -646,7 +646,6 @@ class ActorCriticCnnPolicy(ActorCriticPolicy):
             action_space,
             lr_schedule,
             net_arch,
-            device,
             activation_fn,
             ortho_init,
             use_sde,
@@ -685,7 +684,6 @@ class ContinuousCritic(BaseModel):
     :param activation_fn: (Type[nn.Module]) Activation function
     :param normalize_images: (bool) Whether to normalize images or not,
          dividing by 255.0 (True by default)
-    :param device: (Union[th.device, str]) Device on which the code should run.
     :param n_critics: (int) Number of critic networks to create.
     """
 
@@ -698,7 +696,6 @@ class ContinuousCritic(BaseModel):
         features_dim: int,
         activation_fn: Type[nn.Module] = nn.ReLU,
         normalize_images: bool = True,
-        device: Union[th.device, str] = "auto",
         n_critics: int = 2,
     ):
         super().__init__(
@@ -706,7 +703,6 @@ class ContinuousCritic(BaseModel):
             action_space,
             features_extractor=features_extractor,
             normalize_images=normalize_images,
-            device=device,
         )
 
         action_dim = get_action_dim(self.action_space)

--- a/stable_baselines3/common/policies.py
+++ b/stable_baselines3/common/policies.py
@@ -699,10 +699,7 @@ class ContinuousCritic(BaseModel):
         n_critics: int = 2,
     ):
         super().__init__(
-            observation_space,
-            action_space,
-            features_extractor=features_extractor,
-            normalize_images=normalize_images,
+            observation_space, action_space, features_extractor=features_extractor, normalize_images=normalize_images,
         )
 
         action_dim = get_action_dim(self.action_space)

--- a/stable_baselines3/dqn/policies.py
+++ b/stable_baselines3/dqn/policies.py
@@ -31,10 +31,7 @@ class QNetwork(BasePolicy):
         normalize_images: bool = True,
     ):
         super(QNetwork, self).__init__(
-            observation_space,
-            action_space,
-            features_extractor=features_extractor,
-            normalize_images=normalize_images,
+            observation_space, action_space, features_extractor=features_extractor, normalize_images=normalize_images,
         )
 
         if net_arch is None:

--- a/stable_baselines3/dqn/policies.py
+++ b/stable_baselines3/dqn/policies.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, List, Optional, Type, Union
+from typing import Any, Callable, Dict, List, Optional, Type
 
 import gym
 import torch as th
@@ -15,7 +15,6 @@ class QNetwork(BasePolicy):
     :param observation_space: (gym.spaces.Space) Observation space
     :param action_space: (gym.spaces.Space) Action space
     :param net_arch: (Optional[List[int]]) The specification of the policy and value networks.
-    :param device: (str or th.device) Device on which the code should run.
     :param activation_fn: (Type[nn.Module]) Activation function
     :param normalize_images: (bool) Whether to normalize images or not,
          dividing by 255.0 (True by default)
@@ -28,7 +27,6 @@ class QNetwork(BasePolicy):
         features_extractor: nn.Module,
         features_dim: int,
         net_arch: Optional[List[int]] = None,
-        device: Union[th.device, str] = "auto",
         activation_fn: Type[nn.Module] = nn.ReLU,
         normalize_images: bool = True,
     ):
@@ -37,7 +35,6 @@ class QNetwork(BasePolicy):
             action_space,
             features_extractor=features_extractor,
             normalize_images=normalize_images,
-            device=device,
         )
 
         if net_arch is None:
@@ -90,7 +87,6 @@ class DQNPolicy(BasePolicy):
     :param action_space: (gym.spaces.Space) Action space
     :param lr_schedule: (callable) Learning rate schedule (could be constant)
     :param net_arch: (Optional[List[int]]) The specification of the policy and value networks.
-    :param device: (str or th.device) Device on which the code should run.
     :param activation_fn: (Type[nn.Module]) Activation function
     :param features_extractor_class: (Type[BaseFeaturesExtractor]) Features extractor to use.
     :param features_extractor_kwargs: (Optional[Dict[str, Any]]) Keyword arguments
@@ -109,7 +105,6 @@ class DQNPolicy(BasePolicy):
         action_space: gym.spaces.Space,
         lr_schedule: Callable,
         net_arch: Optional[List[int]] = None,
-        device: Union[th.device, str] = "auto",
         activation_fn: Type[nn.Module] = nn.ReLU,
         features_extractor_class: Type[BaseFeaturesExtractor] = FlattenExtractor,
         features_extractor_kwargs: Optional[Dict[str, Any]] = None,
@@ -120,7 +115,6 @@ class DQNPolicy(BasePolicy):
         super(DQNPolicy, self).__init__(
             observation_space,
             action_space,
-            device,
             features_extractor_class,
             features_extractor_kwargs,
             optimizer_class=optimizer_class,
@@ -143,7 +137,6 @@ class DQNPolicy(BasePolicy):
             "net_arch": self.net_arch,
             "activation_fn": self.activation_fn,
             "normalize_images": normalize_images,
-            "device": device,
         }
 
         self.q_net, self.q_net_target = None, None
@@ -204,7 +197,6 @@ class CnnPolicy(DQNPolicy):
     :param action_space: (gym.spaces.Space) Action space
     :param lr_schedule: (callable) Learning rate schedule (could be constant)
     :param net_arch: (Optional[List[int]]) The specification of the policy and value networks.
-    :param device: (str or th.device) Device on which the code should run.
     :param activation_fn: (Type[nn.Module]) Activation function
     :param features_extractor_class: (Type[BaseFeaturesExtractor]) Features extractor to use.
     :param normalize_images: (bool) Whether to normalize images or not,
@@ -221,7 +213,6 @@ class CnnPolicy(DQNPolicy):
         action_space: gym.spaces.Space,
         lr_schedule: Callable,
         net_arch: Optional[List[int]] = None,
-        device: Union[th.device, str] = "auto",
         activation_fn: Type[nn.Module] = nn.ReLU,
         features_extractor_class: Type[BaseFeaturesExtractor] = NatureCNN,
         features_extractor_kwargs: Optional[Dict[str, Any]] = None,
@@ -234,7 +225,6 @@ class CnnPolicy(DQNPolicy):
             action_space,
             lr_schedule,
             net_arch,
-            device,
             activation_fn,
             features_extractor_class,
             features_extractor_kwargs,

--- a/stable_baselines3/sac/policies.py
+++ b/stable_baselines3/sac/policies.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type
 
 import gym
 import torch as th
@@ -38,7 +38,6 @@ class Actor(BasePolicy):
     :param clip_mean: (float) Clip the mean output when using gSDE to avoid numerical instability.
     :param normalize_images: (bool) Whether to normalize images or not,
          dividing by 255.0 (True by default)
-    :param device: (Union[th.device, str]) Device on which the code should run.
     """
 
     def __init__(
@@ -56,14 +55,12 @@ class Actor(BasePolicy):
         use_expln: bool = False,
         clip_mean: float = 2.0,
         normalize_images: bool = True,
-        device: Union[th.device, str] = "auto",
     ):
         super(Actor, self).__init__(
             observation_space,
             action_space,
             features_extractor=features_extractor,
             normalize_images=normalize_images,
-            device=device,
             squash_output=True,
         )
 
@@ -196,7 +193,6 @@ class SACPolicy(BasePolicy):
     :param action_space: (gym.spaces.Space) Action space
     :param lr_schedule: (callable) Learning rate schedule (could be constant)
     :param net_arch: (Optional[List[int]]) The specification of the policy and value networks.
-    :param device: (str or th.device) Device on which the code should run.
     :param activation_fn: (Type[nn.Module]) Activation function
     :param use_sde: (bool) Whether to use State Dependent Exploration or not
     :param log_std_init: (float) Initial value for the log standard deviation
@@ -225,7 +221,6 @@ class SACPolicy(BasePolicy):
         action_space: gym.spaces.Space,
         lr_schedule: Callable,
         net_arch: Optional[List[int]] = None,
-        device: Union[th.device, str] = "auto",
         activation_fn: Type[nn.Module] = nn.ReLU,
         use_sde: bool = False,
         log_std_init: float = -3,
@@ -242,7 +237,6 @@ class SACPolicy(BasePolicy):
         super(SACPolicy, self).__init__(
             observation_space,
             action_space,
-            device,
             features_extractor_class,
             features_extractor_kwargs,
             optimizer_class=optimizer_class,
@@ -270,7 +264,6 @@ class SACPolicy(BasePolicy):
             "net_arch": self.net_arch,
             "activation_fn": self.activation_fn,
             "normalize_images": normalize_images,
-            "device": device,
         }
         self.actor_kwargs = self.net_args.copy()
         sde_kwargs = {
@@ -356,7 +349,6 @@ class CnnPolicy(SACPolicy):
     :param action_space: (gym.spaces.Space) Action space
     :param lr_schedule: (callable) Learning rate schedule (could be constant)
     :param net_arch: (Optional[List[int]]) The specification of the policy and value networks.
-    :param device: (str or th.device) Device on which the code should run.
     :param activation_fn: (Type[nn.Module]) Activation function
     :param use_sde: (bool) Whether to use State Dependent Exploration or not
     :param log_std_init: (float) Initial value for the log standard deviation
@@ -383,7 +375,6 @@ class CnnPolicy(SACPolicy):
         action_space: gym.spaces.Space,
         lr_schedule: Callable,
         net_arch: Optional[List[int]] = None,
-        device: Union[th.device, str] = "auto",
         activation_fn: Type[nn.Module] = nn.ReLU,
         use_sde: bool = False,
         log_std_init: float = -3,
@@ -402,7 +393,6 @@ class CnnPolicy(SACPolicy):
             action_space,
             lr_schedule,
             net_arch,
-            device,
             activation_fn,
             use_sde,
             log_std_init,

--- a/stable_baselines3/td3/policies.py
+++ b/stable_baselines3/td3/policies.py
@@ -22,7 +22,6 @@ class Actor(BasePolicy):
     :param activation_fn: (Type[nn.Module]) Activation function
     :param normalize_images: (bool) Whether to normalize images or not,
          dividing by 255.0 (True by default)
-    :param device: (Union[th.device, str]) Device on which the code should run.
     """
 
     def __init__(
@@ -34,14 +33,12 @@ class Actor(BasePolicy):
         features_dim: int,
         activation_fn: Type[nn.Module] = nn.ReLU,
         normalize_images: bool = True,
-        device: Union[th.device, str] = "auto",
     ):
         super(Actor, self).__init__(
             observation_space,
             action_space,
             features_extractor=features_extractor,
             normalize_images=normalize_images,
-            device=device,
             squash_output=True,
         )
 
@@ -86,7 +83,6 @@ class TD3Policy(BasePolicy):
     :param action_space: (gym.spaces.Space) Action space
     :param lr_schedule: (Callable) Learning rate schedule (could be constant)
     :param net_arch: (Optional[List[int]]) The specification of the policy and value networks.
-    :param device: (Union[th.device, str]) Device on which the code should run.
     :param activation_fn: (Type[nn.Module]) Activation function
     :param features_extractor_class: (Type[BaseFeaturesExtractor]) Features extractor to use.
     :param features_extractor_kwargs: (Optional[Dict[str, Any]]) Keyword arguments
@@ -106,7 +102,6 @@ class TD3Policy(BasePolicy):
         action_space: gym.spaces.Space,
         lr_schedule: Callable,
         net_arch: Optional[List[int]] = None,
-        device: Union[th.device, str] = "auto",
         activation_fn: Type[nn.Module] = nn.ReLU,
         features_extractor_class: Type[BaseFeaturesExtractor] = FlattenExtractor,
         features_extractor_kwargs: Optional[Dict[str, Any]] = None,
@@ -118,7 +113,6 @@ class TD3Policy(BasePolicy):
         super(TD3Policy, self).__init__(
             observation_space,
             action_space,
-            device,
             features_extractor_class,
             features_extractor_kwargs,
             optimizer_class=optimizer_class,
@@ -146,7 +140,6 @@ class TD3Policy(BasePolicy):
             "net_arch": self.net_arch,
             "activation_fn": self.activation_fn,
             "normalize_images": normalize_images,
-            "device": device,
         }
         self.critic_kwargs = self.net_args.copy()
         self.critic_kwargs.update({"n_critics": n_critics})
@@ -206,7 +199,6 @@ class CnnPolicy(TD3Policy):
     :param action_space: (gym.spaces.Space) Action space
     :param lr_schedule: (Callable) Learning rate schedule (could be constant)
     :param net_arch: (Optional[List[int]]) The specification of the policy and value networks.
-    :param device: (Union[th.device, str]) Device on which the code should run.
     :param activation_fn: (Type[nn.Module]) Activation function
     :param features_extractor_class: (Type[BaseFeaturesExtractor]) Features extractor to use.
     :param features_extractor_kwargs: (Optional[Dict[str, Any]]) Keyword arguments
@@ -226,7 +218,6 @@ class CnnPolicy(TD3Policy):
         action_space: gym.spaces.Space,
         lr_schedule: Callable,
         net_arch: Optional[List[int]] = None,
-        device: Union[th.device, str] = "auto",
         activation_fn: Type[nn.Module] = nn.ReLU,
         features_extractor_class: Type[BaseFeaturesExtractor] = NatureCNN,
         features_extractor_kwargs: Optional[Dict[str, Any]] = None,
@@ -240,7 +231,6 @@ class CnnPolicy(TD3Policy):
             action_space,
             lr_schedule,
             net_arch,
-            device,
             activation_fn,
             features_extractor_class,
             features_extractor_kwargs,

--- a/stable_baselines3/td3/policies.py
+++ b/stable_baselines3/td3/policies.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, List, Optional, Type, Union
+from typing import Any, Callable, Dict, List, Optional, Type
 
 import gym
 import torch as th

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -1,5 +1,6 @@
 import gym
 import pytest
+import torch as th
 
 from stable_baselines3 import A2C, DQN, PPO, SAC, TD3
 from stable_baselines3.common.vec_env import DummyVecEnv
@@ -30,7 +31,11 @@ def test_auto_wrap(model_class):
 
 @pytest.mark.parametrize("model_class", MODEL_LIST)
 @pytest.mark.parametrize("env_id", ["Pendulum-v0", "CartPole-v1"])
-def test_predict(model_class, env_id):
+@pytest.mark.parametrize("device", ["cpu", "cuda", "auto"])
+def test_predict(model_class, env_id, device):
+    if device == "cuda" and not th.cuda.is_available():
+        pytest.skip("CUDA not available")
+
     if env_id == "CartPole-v1":
         if model_class in [SAC, TD3]:
             return
@@ -38,7 +43,7 @@ def test_predict(model_class, env_id):
         return
 
     # test detection of different shapes by the predict method
-    model = model_class("MlpPolicy", env_id)
+    model = model_class("MlpPolicy", env_id, device=device)
     env = gym.make(env_id)
     vec_env = DummyVecEnv([lambda: gym.make(env_id), lambda: gym.make(env_id)])
 


### PR DESCRIPTION
## Description
This fixes issue #111 by removing the `device` keyword argument from policies. It replaces the `device` attribute with a policy that infers the location of the policy from its parameters.

## Motivation and Context

Fixes #111. See that issue for context.

- [x] I have raised an issue to propose this change ([required](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) for new features and bug fixes)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist:

- [x] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [x] I have reformatted the code using `make format` (**required**)
- [x] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [x] I have ensured `make pytest` and `make type` both pass. (**required**)

The `device` argument was not previously mentioned in the Sphinx docs, so I have not updated them (I did update docstrings, though).