### PR TITLE
Allow to set a device when loading a model

### DIFF
--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -14,6 +14,7 @@ New Features:
 ^^^^^^^^^^^^^
 - Added ``unwrap_vec_wrapper()`` to ``common.vec_env`` to extract ``VecEnvWrapper`` if needed
 - Added ``StopTrainingOnMaxEpisodes`` to callback collection (@xicocaio)
+- Added ``device`` keyword argument to ``BaseAlgorithm.load()`` (@liorcohen5)
 
 Bug Fixes:
 ^^^^^^^^^^
@@ -399,4 +400,4 @@ And all the contributors:
 @MarvineGothic @jdossgollin @SyllogismRXS @rusu24edward @jbulow @Antymon @seheevic @justinkterry @edbeeching
 @flodorner @KuKuXia @NeoExtended @PartiallyTyped @mmcenta @richardwu @kinalmehta @rolandgvc @tkelestemur @mloo3
 @tirafesi @blurLake @koulakis @joeljosephjin @shwang @rk37 @andyshih12 @RaphaelWag @xicocaio
-@diditforlulz273
+@diditforlulz273 @liorcohen5

--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -21,6 +21,7 @@ Bug Fixes:
 ^^^^^^^^^^
 - Fixed a bug where the environment was reset twice when using ``evaluate_policy``
 - Fix logging of ``clip_fraction`` in PPO (@diditforlulz273)
+- Fixed a bug where cuda support was wrongly checked when passing the GPU index, e.g., ``device="cuda:0"`` (@liorcohen5)
 
 Deprecations:
 ^^^^^^^^^^^^^

--- a/stable_baselines3/common/base_class.py
+++ b/stable_baselines3/common/base_class.py
@@ -316,13 +316,16 @@ class BaseAlgorithm(ABC):
         return self.policy.predict(observation, state, mask, deterministic)
 
     @classmethod
-    def load(cls, load_path: str, env: Optional[GymEnv] = None, **kwargs) -> "BaseAlgorithm":
+    def load(
+        cls, load_path: str, env: Optional[GymEnv] = None, device: Union[th.device, str] = "auto", **kwargs
+    ) -> "BaseAlgorithm":
         """
         Load the model from a zip-file
 
         :param load_path: the location of the saved data
         :param env: the new environment to run the loaded model on
             (can be None if you only need prediction from a trained model) has priority over any saved environment
+        :param device: (Union[th.device, str]) Device on which the code should run.
         :param kwargs: extra arguments to change the model when loading
         """
         data, params, tensors = load_from_zip_file(load_path)
@@ -352,7 +355,7 @@ class BaseAlgorithm(ABC):
         model = cls(
             policy=data["policy_class"],
             env=env,
-            device="auto",
+            device=device,
             _init_setup_model=False,  # pytype: disable=not-instantiable,wrong-keyword-args
         )
 

--- a/stable_baselines3/common/base_class.py
+++ b/stable_baselines3/common/base_class.py
@@ -328,7 +328,7 @@ class BaseAlgorithm(ABC):
         :param device: (Union[th.device, str]) Device on which the code should run.
         :param kwargs: extra arguments to change the model when loading
         """
-        data, params, tensors = load_from_zip_file(load_path)
+        data, params, tensors = load_from_zip_file(load_path, device=device)
 
         if "policy_kwargs" in data:
             for arg_to_remove in ["device"]:

--- a/stable_baselines3/common/save_util.py
+++ b/stable_baselines3/common/save_util.py
@@ -352,6 +352,7 @@ def load_from_pkl(path: Union[str, pathlib.Path, io.BufferedIOBase], verbose=0) 
 def load_from_zip_file(
     load_path: Union[str, pathlib.Path, io.BufferedIOBase],
     load_data: bool = True,
+    device: Union[th.device, str] = "auto",
     verbose=0,
 ) -> (Tuple[Optional[Dict[str, Any]], Optional[TensorDict], Optional[TensorDict]]):
     """
@@ -360,13 +361,14 @@ def load_from_zip_file(
     :param load_path: (str, pathlib.Path, io.BufferedIOBase) Where to load the model from
     :param load_data: Whether we should load and return data
         (class parameters). Mainly used by 'load_parameters' to only load model parameters (weights)
+    :param device: (Union[th.device, str]) Device on which the code should run.
     :return: (dict),(dict),(dict) Class parameters, model state_dicts (dict of state_dict)
         and dict of extra tensors
     """
     load_path = open_path(load_path, "r", verbose=verbose, suffix="zip")
 
     # set device to cpu if cuda is not available
-    device = get_device()
+    device = get_device(device=device)
 
     # Open the zip archive and load data
     try:

--- a/stable_baselines3/common/utils.py
+++ b/stable_baselines3/common/utils.py
@@ -145,7 +145,7 @@ def get_device(device: Union[th.device, str] = "auto") -> th.device:
     device = th.device(device)
 
     # Cuda not available
-    if device == th.device("cuda") and not th.cuda.is_available():
+    if device.type == th.device("cuda").type and not th.cuda.is_available():
         return th.device("cpu")
 
     return device

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -46,7 +46,7 @@ def test_predict(model_class, env_id, device):
     # Test detection of different shapes by the predict method
     model = model_class("MlpPolicy", env_id, device=device)
     # Check that the policy is on the right device
-    assert get_device(device) == model.policy.device
+    assert get_device(device).type == model.policy.device.type
 
     env = gym.make(env_id)
     vec_env = DummyVecEnv([lambda: gym.make(env_id), lambda: gym.make(env_id)])

--- a/tests/test_save_load.py
+++ b/tests/test_save_load.py
@@ -77,15 +77,18 @@ def test_save_load(tmp_path, model_class):
         model = model_class.load(str(tmp_path / "test_save.zip"), env=env, device=device)
 
         # check if the model was loaded to the correct device
-        assert model.device == get_device(device)
-        assert model.policy.device == get_device(device)
+        assert model.device.type == get_device(device).type
+        assert model.policy.device.type == get_device(device).type
 
         # check if params are still the same after load
         new_params = model.policy.state_dict()
 
         # Check that all params are the same as before save load procedure now
         for key in params:
-            assert th.allclose(params[key], new_params[key]), "Model parameters not the same after save and load."
+            assert new_params[key].device.type == get_device(device).type
+            assert th.allclose(
+                params[key].to("cpu"), new_params[key].to("cpu")
+            ), "Model parameters not the same after save and load."
 
         # check if model still selects the same actions
         new_selected_actions, _ = model.predict(observations, deterministic=True)

--- a/tests/test_save_load.py
+++ b/tests/test_save_load.py
@@ -77,7 +77,8 @@ def test_save_load(tmp_path, model_class):
         model = model_class.load(str(tmp_path / "test_save.zip"), env=env, device=device)
 
         # check if the model was loaded to the correct device
-        assert model.device.type == get_device(device).type
+        assert model.device == get_device(device)
+        assert model.policy.device == get_device(device)
 
         # check if params are still the same after load
         new_params = model.policy.state_dict()

--- a/tests/test_save_load.py
+++ b/tests/test_save_load.py
@@ -13,6 +13,7 @@ from stable_baselines3 import A2C, DDPG, DQN, PPO, SAC, TD3
 from stable_baselines3.common.base_class import BaseAlgorithm
 from stable_baselines3.common.identity_env import FakeImageEnv, IdentityEnv, IdentityEnvBox
 from stable_baselines3.common.save_util import load_from_pkl, open_path, save_to_pkl
+from stable_baselines3.common.utils import get_device
 from stable_baselines3.common.vec_env import DummyVecEnv
 
 MODEL_LIST = [PPO, A2C, TD3, SAC, DQN, DDPG]
@@ -76,10 +77,7 @@ def test_save_load(tmp_path, model_class):
         model = model_class.load(str(tmp_path / "test_save.zip"), env=env, device=device)
 
         # check if the model was loaded to the correct device
-        if th.cuda.is_available():
-            assert model.device.type == (device if isinstance(device, str) else device.type)
-        else:
-            assert model.device.type == "cpu"
+        assert model.device.type == get_device(device).type
 
         # check if params are still the same after load
         new_params = model.policy.state_dict()

--- a/tests/test_save_load.py
+++ b/tests/test_save_load.py
@@ -73,7 +73,7 @@ def test_save_load(tmp_path, model_class):
     del model
 
     # Check if the model loads as expected for every possible choice of device:
-    for device in ["auto", "cpu", "cuda", th.device("cpu"), th.device("cuda")]:
+    for device in ["auto", "cpu", "cuda"]:
         model = model_class.load(str(tmp_path / "test_save.zip"), env=env, device=device)
 
         # check if the model was loaded to the correct device

--- a/tests/test_save_load.py
+++ b/tests/test_save_load.py
@@ -72,8 +72,14 @@ def test_save_load(tmp_path, model_class):
     del model
 
     # Check if the model loads as expected for every possible choice of device:
-    for device in ["auto", "cpu", "cuda"]:
+    for device in ["auto", "cpu", "cuda", th.device("cpu"), th.device("cuda")]:
         model = model_class.load(str(tmp_path / "test_save.zip"), env=env, device=device)
+
+        # check if the model was loaded to the correct device
+        if th.cuda.is_available():
+            assert model.device.type == (device if isinstance(device, str) else device.type)
+        else:
+            assert model.device.type == "cpu"
 
         # check if params are still the same after load
         new_params = model.policy.state_dict()


### PR DESCRIPTION
Added a 'device' keyword argument to BaseAlgorithm.load(), to enable users to set the model to their device of choice.
Edited test_save_load to also test the load method with all possible devices.
Added the changes to the changelog (I'm not completely confident about the choice of words though).

## Description
Added a 'device' keyword argument with default value 'auto', similarly to the hard-coded value that was used before my change to BaseAlgorithm.load(), and forwarded it to the C'tor call inside the load method (instead of the hard-coded string parameter).

## Motivation and Context
I'm using this repo for my research and when I work with simpler models (tiny MLP for example) it is actually faster to use the CPU even though my machine has a powerful GPU since the overhead of the calls is higher than the benefits.
Thus, when I load the models I'm training, I need to be able to force them to load to the CPU easily.
Since I've seen that the code is already there but currently the device is chosen using a hard-coded string inside the load method, I suggested to make this little but significant change (:

Closes #153 
- [x] I have raised an issue to propose this change ([required](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) for new features and bug fixes)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist:
- [x] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the changelog accordingly (**required**).
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
- [x] I have reformatted the code using `make format` (**required**)
- [x] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [x] I have ensured `make pytest` and `make type` both pass. (**required**)
