### PR TITLE
Fix ignoring the exclude in the logger's record function for json, csv and log logging formats

### DIFF
--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -17,6 +17,7 @@ New Features:
 Bug Fixes:
 ^^^^^^^^^^
 - Fix GAE computation for on-policy algorithms (off-by one for the last value) (thanks @Wovchena)
+- Fix ignoring the exclude parameter when recording logs using json, csv or log as logging format (@SwamyDev)
 
 Deprecations:
 ^^^^^^^^^^^^^
@@ -453,4 +454,4 @@ And all the contributors:
 @MarvineGothic @jdossgollin @SyllogismRXS @rusu24edward @jbulow @Antymon @seheevic @justinkterry @edbeeching
 @flodorner @KuKuXia @NeoExtended @PartiallyTyped @mmcenta @richardwu @kinalmehta @rolandgvc @tkelestemur @mloo3
 @tirafesi @blurLake @koulakis @joeljosephjin @shwang @rk37 @andyshih12 @RaphaelWag @xicocaio
-@diditforlulz273 @liorcohen5 @ManifoldFR @mloo3
+@diditforlulz273 @liorcohen5 @ManifoldFR @mloo3 @SwamyDev

--- a/stable_baselines3/common/logger.py
+++ b/stable_baselines3/common/logger.py
@@ -80,7 +80,7 @@ class HumanOutputFormat(KVWriter, SeqWriter):
         tag = None
         for (key, value), (_, excluded) in zip(sorted(key_values.items()), sorted(key_excluded.items())):
 
-            if excluded is not None and "stdout" in excluded:
+            if excluded is not None and ("stdout" in excluded or "log" in excluded):
                 continue
 
             if isinstance(value, float):
@@ -140,6 +140,23 @@ class HumanOutputFormat(KVWriter, SeqWriter):
             self.file.close()
 
 
+def filter_excluded_keys(
+    key_values: Dict[str, Any], key_excluded: Dict[str, Union[str, Tuple[str, ...]]], _format: str
+) -> Dict[str, Any]:
+    """
+    filters the keys specified by `key_exclude` for the specified format
+
+    :param key_values: log dictionary to be filtered
+    :param key_excluded: keys to be excluded per format
+    :param _format: format for which this filter is run
+    """
+
+    def is_excluded(key):
+        return key in key_excluded and key_excluded[key] is not None and _format in key_excluded[key]
+
+    return {key: value for key, value in key_values.items() if not is_excluded(key)}
+
+
 class JSONOutputFormat(KVWriter):
     def __init__(self, filename: str):
         """
@@ -150,18 +167,20 @@ class JSONOutputFormat(KVWriter):
         self.file = open(filename, "wt")
 
     def write(self, key_values: Dict[str, Any], key_excluded: Dict[str, Union[str, Tuple[str, ...]]], step: int = 0) -> None:
-        for (key, value), (_, excluded) in zip(sorted(key_values.items()), sorted(key_excluded.items())):
-
-            if excluded is not None and "json" in excluded:
-                continue
-
+        def cast_to_json_serializable(value):
             if hasattr(value, "dtype"):
                 if value.shape == () or len(value) == 1:
                     # if value is a dimensionless numpy array or of length 1, serialize as a float
-                    key_values[key] = float(value)
+                    return float(value)
                 else:
                     # otherwise, a value is a numpy array, serialize as a list or nested lists
-                    key_values[key] = value.tolist()
+                    return value.tolist()
+            return value
+
+        key_values = {
+            key: cast_to_json_serializable(value)
+            for key, value in filter_excluded_keys(key_values, key_excluded, "json").items()
+        }
         self.file.write(json.dumps(key_values) + "\n")
         self.file.flush()
 
@@ -187,6 +206,7 @@ class CSVOutputFormat(KVWriter):
 
     def write(self, key_values: Dict[str, Any], key_excluded: Dict[str, Union[str, Tuple[str, ...]]], step: int = 0) -> None:
         # Add our current row to the history
+        key_values = filter_excluded_keys(key_values, key_excluded, "csv")
         extra_keys = key_values.keys() - self.keys
         if extra_keys:
             self.keys.extend(extra_keys)

--- a/stable_baselines3/common/logger.py
+++ b/stable_baselines3/common/logger.py
@@ -152,7 +152,7 @@ def filter_excluded_keys(
     :return: dict without the excluded keys
     """
 
-    def is_excluded(key: str):
+    def is_excluded(key: str) -> bool:
         return key in key_excluded and key_excluded[key] is not None and _format in key_excluded[key]
 
     return {key: value for key, value in key_values.items() if not is_excluded(key)}

--- a/stable_baselines3/common/logger.py
+++ b/stable_baselines3/common/logger.py
@@ -152,7 +152,7 @@ def filter_excluded_keys(
     :return: dict without the excluded keys
     """
 
-    def is_excluded(key):
+    def is_excluded(key: str):
         return key in key_excluded and key_excluded[key] is not None and _format in key_excluded[key]
 
     return {key: value for key, value in key_values.items() if not is_excluded(key)}
@@ -168,7 +168,7 @@ class JSONOutputFormat(KVWriter):
         self.file = open(filename, "wt")
 
     def write(self, key_values: Dict[str, Any], key_excluded: Dict[str, Union[str, Tuple[str, ...]]], step: int = 0) -> None:
-        def cast_to_json_serializable(value):
+        def cast_to_json_serializable(value: Any):
             if hasattr(value, "dtype"):
                 if value.shape == () or len(value) == 1:
                     # if value is a dimensionless numpy array or of length 1, serialize as a float

--- a/stable_baselines3/common/logger.py
+++ b/stable_baselines3/common/logger.py
@@ -144,11 +144,12 @@ def filter_excluded_keys(
     key_values: Dict[str, Any], key_excluded: Dict[str, Union[str, Tuple[str, ...]]], _format: str
 ) -> Dict[str, Any]:
     """
-    filters the keys specified by `key_exclude` for the specified format
+    Filters the keys specified by ``key_exclude`` for the specified format
 
     :param key_values: log dictionary to be filtered
     :param key_excluded: keys to be excluded per format
     :param _format: format for which this filter is run
+    :return: dict without the excluded keys
     """
 
     def is_excluded(key):


### PR DESCRIPTION
## Description
I've introduced a general `filter_excluded_keys` function which takes `key_values` and `key_excluded` dictionaries as well as a logging `_format` specifier to remove excluded keys from the  `key_values` dictionary. This function is then used in `JSONOutputFormat` and `CSVOutputFormat` to remove excluded keys before any further processing is done. In `HumanOutputFormat` I've simply added an additional check for the `log` format type. 

In `test_logger.py` I've introduced regression tests, that check that all `*Format` objects produce no output when the key written is excluded. To do that I've introduced a new `read_log` fixture, which reads the contents from files, captured standard output and Tensorboard events and wraps it in a content interface. The wrapper makes the test check more convenient because I can just assert for the empty property for any logging format type. I've also used the `read_log` fixture in the `test_make_output` test, to make sure that the read_log function is actually reading content when it should. As a side effect the `test_make_output` function is imo a bit more thorough by also checking for content of log and Tensorboard.

## Motivation and Context
Currently using the `exclude` parameter of the logger's `record` function would be ignored for csv, json and log formats. 
closes #187 

- [x] I have raised an issue to propose this change ([required](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) for new features and bug fixes)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (update in the documentation)

## Checklist:
- [x] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [x] I have reformatted the code using `make format` (**required**)
- [x] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [x] I have ensured `make pytest` and `make type` both pass. (**required**)


## Side Notes
I've also been running `make commit-checks` and `make type`, however I do get to errors in `base_class.py` even on a fresh clone:
```bash
File "/tmp/stable-baselines3/stable_baselines3/common/base_class.py", line 587, in load: Can't instantiate BaseAlgorithm with abstract methods _setup_model, learn [not-instantiable]
File "/tmp/stable-baselines3/stable_baselines3/common/base_class.py", line 587, in load: Invalid keyword argument _init_setup_model to function BaseAlgorithm.__init__ [wrong-keyword-args]
         Expected: (self, policy, env, policy_base, learning_rate, policy_kwargs, tensorboard_log, verbose, device, support_multi_env, create_eval_env, monitor_wrapper, seed, use_sde, sde_sample_freq)
  Actually passed: (self, policy, env, device, _init_setup_model)
```
Is this to be expected as it is still part of the rework, or is this possibly a problem with my pytype installation (version 2020.10.8)?
