### PR TITLE
add check to ensure action space is non-dict non-tuple for env_checker nan check

### DIFF
--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -20,6 +20,7 @@ Bug Fixes:
 - Fix ignoring the exclude parameter when recording logs using json, csv or log as logging format (@SwamyDev)
 - Make ``make_vec_env`` support the ``env_kwargs`` argument when using an env ID str (@ManifoldFR)
 - Fix ``check_env`` not checking if the env has a Dict actionspace before calling ``_check_nan`` (@wmmc88)
+- Update the check for spaces unsupported by Stable Baselines 3 to include checks on the action space (@wmmc88)
 
 Deprecations:
 ^^^^^^^^^^^^^

--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -19,6 +19,7 @@ Bug Fixes:
 - Fix GAE computation for on-policy algorithms (off-by one for the last value) (thanks @Wovchena)
 - Fix ignoring the exclude parameter when recording logs using json, csv or log as logging format (@SwamyDev)
 - Make ``make_vec_env`` support the ``env_kwargs`` argument when using an env ID str (@ManifoldFR)
+- Fix ``check_env`` not checking if the env has a Dict actionspace before calling ``_check_nan`` (@wmmc88)
 
 Deprecations:
 ^^^^^^^^^^^^^
@@ -456,4 +457,4 @@ And all the contributors:
 @MarvineGothic @jdossgollin @SyllogismRXS @rusu24edward @jbulow @Antymon @seheevic @justinkterry @edbeeching
 @flodorner @KuKuXia @NeoExtended @PartiallyTyped @mmcenta @richardwu @kinalmehta @rolandgvc @tkelestemur @mloo3
 @tirafesi @blurLake @koulakis @joeljosephjin @shwang @rk37 @andyshih12 @RaphaelWag @xicocaio
-@diditforlulz273 @liorcohen5 @ManifoldFR @mloo3 @SwamyDev
+@diditforlulz273 @liorcohen5 @ManifoldFR @mloo3 @SwamyDev @wmmc88

--- a/stable_baselines3/common/env_checker.py
+++ b/stable_baselines3/common/env_checker.py
@@ -15,12 +15,14 @@ def _enforce_array_obs(observation_space: spaces.Space) -> bool:
     """
     return not isinstance(observation_space, (spaces.Dict, spaces.Tuple))
 
+
 def _enforce_array_act(action_space: spaces.Space) -> bool:
     """
     Whether to check that the returned action is a numpy array
     `Dict` and `Tuple` spaces are not guaranteed to contain only numpy arrays
     """
     return not isinstance(action_space, (spaces.Dict, spaces.Tuple))
+
 
 def _check_image_input(observation_space: spaces.Box) -> None:
     """

--- a/stable_baselines3/common/env_checker.py
+++ b/stable_baselines3/common/env_checker.py
@@ -11,10 +11,16 @@ from stable_baselines3.common.vec_env import DummyVecEnv, VecCheckNan
 def _enforce_array_obs(observation_space: spaces.Space) -> bool:
     """
     Whether to check that the returned observation is a numpy array
-    it is not mandatory for `Dict` and `Tuple` spaces.
+    `Dict` and `Tuple` spaces are not guaranteed to contain only numpy arrays
     """
     return not isinstance(observation_space, (spaces.Dict, spaces.Tuple))
 
+def _enforce_array_act(action_space: spaces.Space) -> bool:
+    """
+    Whether to check that the returned action is a numpy array
+    `Dict` and `Tuple` spaces are not guaranteed to contain only numpy arrays
+    """
+    return not isinstance(action_space, (spaces.Dict, spaces.Tuple))
 
 def _check_image_input(observation_space: spaces.Box) -> None:
     """
@@ -234,5 +240,5 @@ def check_env(env: gym.Env, warn: bool = True, skip_render_check: bool = True) -
         _check_render(env, warn=warn)
 
     # The check only works with numpy arrays
-    if _enforce_array_obs(observation_space):
+    if _enforce_array_obs(observation_space) and _enforce_array_act(action_space):
         _check_nan(env)

--- a/stable_baselines3/common/env_checker.py
+++ b/stable_baselines3/common/env_checker.py
@@ -10,8 +10,8 @@ from stable_baselines3.common.vec_env import DummyVecEnv, VecCheckNan
 
 def _is_numpy_array_space(space: spaces.Space) -> bool:
     """
-    Checks whether the space consists of a numpy array
-    `Dict` and `Tuple` spaces are not just a numpy array
+    Returns False if provided space is not representable as a single numpy array
+    (e.g. Dict and Tuple spaces return False)
     """
     return not isinstance(space, (spaces.Dict, spaces.Tuple))
 
@@ -46,7 +46,7 @@ def _check_image_input(observation_space: spaces.Box) -> None:
 
 
 def _check_unsupported_spaces(env: gym.Env, observation_space: spaces.Space, action_space: spaces.Space) -> None:
-    """Emit warnings when the observation space used is not supported by Stable-Baselines."""
+    """Emit warnings when the observation space or action space used is not supported by Stable-Baselines."""
 
     if isinstance(observation_space, spaces.Dict) and not isinstance(env, gym.GoalEnv):
         warnings.warn(

--- a/tests/test_env_checker.py
+++ b/tests/test_env_checker.py
@@ -6,10 +6,7 @@ from stable_baselines3.common.env_checker import check_env
 
 
 class ActionDictTestEnv(gym.Env):
-    action_space = Dict({
-        "position": Discrete(1),
-        "velocity": Discrete(1)
-    })
+    action_space = Dict({"position": Discrete(1), "velocity": Discrete(1)})
     observation_space = Box(low=-1.0, high=2.0, shape=(3,), dtype=np.float32)
 
     def step(self, action):
@@ -22,7 +19,7 @@ class ActionDictTestEnv(gym.Env):
     def reset(self):
         return np.array([1.0, 1.5, 0.5])
 
-    def render(self, mode='human'):
+    def render(self, mode="human"):
         pass
 
 

--- a/tests/test_env_checker.py
+++ b/tests/test_env_checker.py
@@ -1,5 +1,6 @@
 import gym
 import numpy as np
+import pytest
 from gym.spaces import Box, Dict, Discrete
 
 from stable_baselines3.common.env_checker import check_env
@@ -25,4 +26,6 @@ class ActionDictTestEnv(gym.Env):
 
 def test_check_env_dict_action():
     test_env = ActionDictTestEnv()
-    check_env(env=test_env, warn=True)
+
+    with pytest.warns(Warning):
+        check_env(env=test_env, warn=True)

--- a/tests/test_env_checker.py
+++ b/tests/test_env_checker.py
@@ -1,0 +1,31 @@
+import gym
+import numpy as np
+from gym.spaces import Box, Dict, Discrete
+
+from stable_baselines3.common.env_checker import check_env
+
+
+class ActionDictTestEnv(gym.Env):
+    action_space = Dict({
+        "position": Discrete(1),
+        "velocity": Discrete(1)
+    })
+    observation_space = Box(low=-1.0, high=2.0, shape=(3,), dtype=np.float32)
+
+    def step(self, action):
+        observation = np.array([1.0, 1.5, 0.5])
+        reward = 1
+        done = True
+        info = {}
+        return observation, reward, done, info
+
+    def reset(self):
+        return np.array([1.0, 1.5, 0.5])
+
+    def render(self, mode='human'):
+        pass
+
+
+def test_check_env_dict_action():
+    test_env = ActionDictTestEnv()
+    check_env(env=test_env, warn=True)


### PR DESCRIPTION
## Description
Fix `check_env` not checking if the env has a Dict actionspace before calling `_check_nan`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->

- [x] I have raised an issue to propose this change ([required](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) for new features and bug fixes)

fixes #191 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [x] I have reformatted the code using `make format` (**required**)
- [x] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [x] I have ensured `make pytest` and `make type` both pass. (**required**)


Note: we are using a maximum length of 127 characters per line

<!--- This Template is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->
