### PR TITLE
Fix initializing CUDA even when `device="cpu"` is used.

### DIFF
--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -19,6 +19,7 @@ Bug Fixes:
 - Fix GAE computation for on-policy algorithms (off-by one for the last value) (thanks @Wovchena)
 - Fix ignoring the exclude parameter when recording logs using json, csv or log as logging format (@SwamyDev)
 - Make ``make_vec_env`` support the ``env_kwargs`` argument when using an env ID str (@ManifoldFR)
+- Fix model creation initializing CUDA even when `device="cpu"` is provided
 
 Deprecations:
 ^^^^^^^^^^^^^

--- a/stable_baselines3/common/policies.py
+++ b/stable_baselines3/common/policies.py
@@ -112,12 +112,12 @@ class BaseModel(nn.Module, ABC):
     @property
     def device(self) -> th.device:
         """Infer which device this policy lives on by inspecting its parameters.
-        If it has no parameters, the 'auto' device is used as a fallback.
+        If it has no parameters, the 'cpu' device is used as a fallback.
 
         :return:"""
         for param in self.parameters():
             return param.device
-        return get_device("auto")
+        return get_device("cpu")
 
     def save(self, path: str) -> None:
         """
@@ -447,7 +447,9 @@ class ActorCriticPolicy(BasePolicy):
         # Note: If net_arch is None and some features extractor is used,
         #       net_arch here is an empty list and mlp_extractor does not
         #       really contain any layers (acts like an identity module).
-        self.mlp_extractor = MlpExtractor(self.features_dim, net_arch=self.net_arch, activation_fn=self.activation_fn)
+        self.mlp_extractor = MlpExtractor(
+            self.features_dim, net_arch=self.net_arch, activation_fn=self.activation_fn, device=self.device
+        )
 
     def _build(self, lr_schedule: Callable[[float], float]) -> None:
         """


### PR DESCRIPTION
## Description
`MlpExtractor` defaults to using "auto" device when none is provided (i.e. GPU if available), and this also happened when `device="cpu"` was given to the agent (result of #141). These parameters are then moved to desired device by training algorithm after creation.

This update makes "cpu" the fallback device if none is provided. We might want to formalize that by default everything is put on "cpu" in policies and let learning algorithms do all the moving to right devices.

I could not come up for a reliable this as there is no way to release the memory used from CUDA-initialization (only for clearing any tensors), so if any previous testing code uses any CUDA parts then this can not be tested.

## Motivation and Context
Closes #193
- [x] I have raised an issue to propose this change ([required](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) for new features and bug fixes)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [x] I have reformatted the code using `make format` (**required**)
- [x] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [x] I have ensured `make pytest` and `make type` both pass. (**required**)
