### PR TITLE
Fix for the arguments order in explained_variance

### DIFF
--- a/stable_baselines3/common/utils.py
+++ b/stable_baselines3/common/utils.py
@@ -39,7 +39,7 @@ def set_random_seed(seed: int, using_cuda: bool = False) -> None:
 
 
 # From stable baselines
-def explained_variance(y_pred: np.ndarray, y_true: np.ndarray) -> np.ndarray:
+def explained_variance(y_true: np.ndarray, y_pred: np.ndarray) -> np.ndarray:
     """
     Computes fraction of variance that ypred explains about y.
     Returns 1 - Var[y-ypred] / Var[y]


### PR DESCRIPTION
This commit is for fixing the issue: https://github.com/DLR-RM/stable-baselines3/issues/225
Change: `explained_variance(y_pred, y_true)` -> `explained_variance(y_true, y_pred)`
This function is used in `ppo.py` and `a2c.py`. And I think this format (`true, pred`) is much like sklearn and torch style.