### PR TITLE
add optional render argument to SubprocVecEnv

### DIFF
--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -26,6 +26,8 @@ New Features:
 - Added ``monitor_kwargs`` parameter to ``make_vec_env`` and ``make_atari_env``
 - Wrap the environments automatically with a ``Monitor`` wrapper when possible.
 - ``EvalCallback`` now logs the success rate when available (``is_success`` must be present in the info dict)
+- Added ``render`` argument to ``SubprocVecEnv`` and ``DummyVecEnv`` enabling
+  rendering of terminal steps.
 
 Bug Fixes:
 ^^^^^^^^^^


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds an optional `render` argument to `SubprocVecEnv` and `DummyVecEnv` which renders each step, including terminal steps.

## Description
<!--- Describe your changes in detail -->
- adds a `render` argument to aforesaid classes
- adds a `render_mode` argument to aforesaid classes
- renders each step (including terminal) if `render == True`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
In order to render the terminal step of an episode, `.render()` must be called within the `.step` method of `VecEnv`. For some environments it is important to be able to view the terminal step for debugging purposes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (update in the documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the changelog accordingly (**required**).
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
- [x] I have reformatted the code using `make format` (**required**)
- [x] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [x] I have ensured `make pytest` 
- [ ]  and `make type` both pass. (**required**) -- this threw an error before my changes at `stable_baselines3.common.base_class`
- [x] I have checked that the documentation builds using `make doc` (**required**)

Note: You can run most of the checks using `make commit-checks`.

Note: we are using a maximum length of 127 characters per line

<!--- This Template is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->
