### PR TITLE
Added new project using SB3 in the documentation: rl_reach

### DIFF
--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -13,6 +13,7 @@ Breaking Changes:
 Documentation:
 ^^^^^^^^^^^^^^
 - Fixed examples
+- Added new project using SB3: rl_reach (@PierreExeter)
 
 
 Pre-Release 0.11.1 (2021-02-27)
@@ -588,4 +589,4 @@ And all the contributors:
 @tirafesi @blurLake @koulakis @joeljosephjin @shwang @rk37 @andyshih12 @RaphaelWag @xicocaio
 @diditforlulz273 @liorcohen5 @ManifoldFR @mloo3 @SwamyDev @wmmc88 @megan-klaiber @thisray
 @tfederico @hn2 @LucasAlegre @AptX395 @zampanteymedio @decodyng @ardabbour @lorenz-h @mschweizer @lorepieri8
-@ShangqunYu
+@ShangqunYu @PierreExeter

--- a/docs/misc/projects.rst
+++ b/docs/misc/projects.rst
@@ -15,6 +15,15 @@ Please tell us, if you want your project to appear on this page ;)
 .. | Author: Antonin Raffin  (@araffin)
 .. | Github repo: https://github.com/araffin/RL-Racing-Robot
 
+rl_reach
+--------
+
+A platform for running reproducible reinforcement learning experiments for customisable robotic reaching tasks. This self-contained and straightforward toolbox allows its users to quickly investigate and identify optimal training configurations.
+
+| Authors: Pierre Aumjaud, David McAuliffe, Francisco Javier Rodríguez Lera, Philip Cardiff
+| Github: https://github.com/PierreExeter/rl_reach
+| Paper: https://arxiv.org/abs/2102.04916
+
 
 Generalized State Dependent Exploration for Deep Reinforcement Learning in Robotics
 -----------------------------------------------------------------------------------


### PR DESCRIPTION
## Description
I'm updating the project page of the documentation with a new entry: rl_reach (toolbox for running RL experiments based on SB3).

## Motivation and Context
This addition to the documentation was discussed with @araffin by email. 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) for new features and bug fixes)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (update in the documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the changelog accordingly (**required**).
- [x] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
- [x] I have reformatted the code using `make format` (**required**)
- [x] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [ ] I have ensured `make pytest` and `make type` both pass. (**required**)
- [x] I have checked that the documentation builds using `make doc` (**required**)

When running `make pytest`, 25 tests are failing (see test summary info below). This is strange since I didn't modify the source code, only the documentation. Most of these tests failing seem to be due to connection error, so maybe it can be ignored.

```bash
FAILED tests/test_identity.py::test_discrete[env2-PPO] - AssertionError: Mean reward below threshold: 87.20 < 90.00
FAILED tests/test_utils.py::test_make_vec_env[None-SubprocVecEnv-1-CartPole-v1] - ConnectionResetError: [Errno 104] Connection reset by peer
FAILED tests/test_utils.py::test_make_vec_env[None-SubprocVecEnv-1-<lambda>] - ConnectionResetError: [Errno 104] Connection reset by peer
FAILED tests/test_utils.py::test_make_vec_env[None-SubprocVecEnv-2-CartPole-v1] - ConnectionResetError: [Errno 104] Connection reset by peer
FAILED tests/test_utils.py::test_make_vec_env[None-SubprocVecEnv-2-<lambda>] - ConnectionResetError: [Errno 104] Connection reset by peer
FAILED tests/test_utils.py::test_make_vec_env[TimeLimit-SubprocVecEnv-1-CartPole-v1] - ConnectionResetError: [Errno 104] Connection reset by peer
FAILED tests/test_utils.py::test_make_vec_env[TimeLimit-SubprocVecEnv-1-<lambda>] - ConnectionResetError: [Errno 104] Connection reset by peer
FAILED tests/test_utils.py::test_make_vec_env[TimeLimit-SubprocVecEnv-2-CartPole-v1] - ConnectionResetError: [Errno 104] Connection reset by peer
FAILED tests/test_utils.py::test_make_vec_env[TimeLimit-SubprocVecEnv-2-<lambda>] - ConnectionResetError: [Errno 104] Connection reset by peer
FAILED tests/test_utils.py::test_custom_vec_env - ConnectionResetError: [Errno 104] Connection reset by peer
FAILED tests/test_utils.py::test_evaluate_policy_monitors[SubprocVecEnv] - ConnectionResetError: [Errno 104] Connection reset by peer
FAILED tests/test_vec_envs.py::test_vecenv_custom_calls[None-SubprocVecEnv] - ConnectionResetError: [Errno 104] Connection reset by peer
FAILED tests/test_vec_envs.py::test_vecenv_custom_calls[VecNormalize-SubprocVecEnv] - ConnectionResetError: [Errno 104] Connection reset by peer
FAILED tests/test_vec_envs.py::test_vecenv_custom_calls[VecFrameStack-SubprocVecEnv] - ConnectionResetError: [Errno 104] Connection reset by peer
FAILED tests/test_vec_envs.py::test_vecenv_terminal_obs[None-SubprocVecEnv] - ConnectionResetError: [Errno 104] Connection reset by peer
FAILED tests/test_vec_envs.py::test_vecenv_terminal_obs[VecNormalize-SubprocVecEnv] - ConnectionResetError: [Errno 104] Connection reset by peer
FAILED tests/test_vec_envs.py::test_vecenv_terminal_obs[VecFrameStack-SubprocVecEnv] - ConnectionResetError: [Errno 104] Connection reset by peer
FAILED tests/test_vec_envs.py::test_vecenv_single_space[SubprocVecEnv-space4] - ConnectionResetError: [Errno 104] Connection reset by peer
FAILED tests/test_vec_envs.py::test_vecenv_single_space[SubprocVecEnv-space5] - ConnectionResetError: [Errno 104] Connection reset by peer
FAILED tests/test_vec_envs.py::test_vecenv_single_space[SubprocVecEnv-space6] - ConnectionResetError: [Errno 104] Connection reset by peer
FAILED tests/test_vec_envs.py::test_vecenv_single_space[SubprocVecEnv-space7] - ConnectionResetError: [Errno 104] Connection reset by peer
FAILED tests/test_vec_envs.py::test_vecenv_dict_spaces[SubprocVecEnv] - ConnectionResetError: [Errno 104] Connection reset by peer
FAILED tests/test_vec_envs.py::test_vecenv_tuple_spaces[SubprocVecEnv] - ConnectionResetError: [Errno 104] Connection reset by peer
FAILED tests/test_vec_envs.py::test_subproc_start_method - ConnectionResetError: [Errno 104] Connection reset by peer
FAILED tests/test_vec_envs.py::test_vec_env_is_wrapped - ConnectionResetError: [Errno 104] Connection reset by peer
```

Note: You can run most of the checks using `make commit-checks`.

Note: we are using a maximum length of 127 characters per line

<!--- This Template is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->
