### PR TITLE
Add note on loading and resetting environments

### DIFF
--- a/docs/guide/examples.rst
+++ b/docs/guide/examples.rst
@@ -487,9 +487,9 @@ Behind the scene, SB3 uses an :ref:`EvalCallback <callbacks>`.
 
 .. note::
 
-	For the training model after loading it we recommend loading the replay buffer to ensure stable learning.
+	For training model after loading it, we recommend loading the replay buffer to ensure stable learning (for off-policy algorithms).
 	You also need to pass ``reset_num_timesteps=True`` to ``learn`` function which initializes the environment
-	and agent for training if a new environment is created since saving the model.
+	and agent for training if a new environment was created since saving the model.
 
 
 .. image:: ../_static/img/colab-badge.svg

--- a/docs/guide/examples.rst
+++ b/docs/guide/examples.rst
@@ -480,12 +480,21 @@ By default, the replay buffer is not saved when calling ``model.save()``, in ord
 However, SB3 provides a ``save_replay_buffer()`` and ``load_replay_buffer()`` method to save it separately.
 
 
-.. image:: ../_static/img/colab-badge.svg
-   :target: https://colab.research.google.com/github/Stable-Baselines-Team/rl-colab-notebooks/blob/sb3/advanced_saving_loading.ipynb
-
 Stable-Baselines3 automatic creation of an environment for evaluation.
 For that, you only need to specify ``create_eval_env=True`` when passing the Gym ID of the environment while creating the agent.
 Behind the scene, SB3 uses an :ref:`EvalCallback <callbacks>`.
+
+
+.. note:
+
+  For the training model after loading it we recommend loading the replay buffer to ensure stable learning.
+	You also need to pass ``reset_num_timesteps=True`` to ``learn`` function which initializes the environment
+	and agent for training if a new environment is created since saving the model.
+
+
+.. image:: ../_static/img/colab-badge.svg
+   :target: https://colab.research.google.com/github/Stable-Baselines-Team/rl-colab-notebooks/blob/sb3/advanced_saving_loading.ipynb
+
 
 .. code-block:: python
 

--- a/docs/guide/examples.rst
+++ b/docs/guide/examples.rst
@@ -485,9 +485,9 @@ For that, you only need to specify ``create_eval_env=True`` when passing the Gym
 Behind the scene, SB3 uses an :ref:`EvalCallback <callbacks>`.
 
 
-.. note:
+.. note::
 
-  For the training model after loading it we recommend loading the replay buffer to ensure stable learning.
+	For the training model after loading it we recommend loading the replay buffer to ensure stable learning.
 	You also need to pass ``reset_num_timesteps=True`` to ``learn`` function which initializes the environment
 	and agent for training if a new environment is created since saving the model.
 

--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -14,6 +14,7 @@ Documentation:
 ^^^^^^^^^^^^^^
 - Fixed examples
 - Added new project using SB3: rl_reach (@PierreExeter)
+- Add a note on continual learning and resetting environment
 
 
 Pre-Release 0.11.1 (2021-02-27)


### PR DESCRIPTION
Add a note clarifying the need of resetting environment after loading it in a new script.

I also thought about adding assertion-checks but ideas I had interfered with other use cases so I just update docs for now. Feel free to comment on this.

## Motivation and Context
- [x] I have raised an issue to propose this change ([required](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) for new features and bug fixes)

Related issue #339

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (update in the documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the changelog accordingly (**required**).
- [x] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
- [ ] I have reformatted the code using `make format` (**required**)
- [ ] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [ ] I have ensured `make pytest` and `make type` both pass. (**required**)
- [ ] I have checked that the documentation builds using `make doc` (**required**)