### PR TITLE
Make installation command compatible with ZSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,9 @@ To install stable-baselines on Windows, please look at the [documentation](https
 ### Install using pip
 Install the Stable Baselines3 package:
 ```
-pip install "stable-baselines3[extra]"
+pip install stable-baselines3[extra]
 ```
+Note: Some shells such as Zsh require quotation marks around brackets, i.e. `pip install 'stable-baselines3[extra]'` ([More Info](https://stackoverflow.com/a/30539963)).
 
 This includes an optional dependencies like Tensorboard, OpenCV or `atari-py` to train on atari games. If you do not need those, you can use:
 ```

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Install the Stable Baselines3 package:
 ```
 pip install stable-baselines3[extra]
 ```
-Note: Some shells such as Zsh require quotation marks around brackets, i.e. `pip install 'stable-baselines3[extra]'` ([More Info](https://stackoverflow.com/a/30539963)).
+**Note:** Some shells such as Zsh require quotation marks around brackets, i.e. `pip install 'stable-baselines3[extra]'` ([More Info](https://stackoverflow.com/a/30539963)).
 
 This includes an optional dependencies like Tensorboard, OpenCV or `atari-py` to train on atari games. If you do not need those, you can use:
 ```

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ To install stable-baselines on Windows, please look at the [documentation](https
 ### Install using pip
 Install the Stable Baselines3 package:
 ```
-pip install stable-baselines3[extra]
+pip install "stable-baselines3[extra]"
 ```
 
 This includes an optional dependencies like Tensorboard, OpenCV or `atari-py` to train on atari games. If you do not need those, you can use:

--- a/docs/guide/install.rst
+++ b/docs/guide/install.rst
@@ -29,6 +29,10 @@ To install Stable Baselines3 with pip, execute:
 
     pip install stable-baselines3[extra]
 
+.. note::
+        Some shells such as Zsh require quotation marks around brackets, i.e. ``pip install 'stable-baselines3[extra]'`` `More information <https://stackoverflow.com/a/30539963>`_. 
+
+
 This includes an optional dependencies like Tensorboard, OpenCV or ``atari-py`` to train on atari games. If you do not need those, you can use:
 
 .. code-block:: bash

--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -31,6 +31,7 @@ Documentation:
 - Added link to SuperSuit in projects (@justinkterry)
 - Fixed DQN example (thanks @ltbd78)
 - Clarify channel-first/channel-last recommendation
+- Clarify pip installation in Zsh (@tom-doerr)
 
 
 Release 1.0 (2021-03-15)
@@ -640,4 +641,4 @@ And all the contributors:
 @tirafesi @blurLake @koulakis @joeljosephjin @shwang @rk37 @andyshih12 @RaphaelWag @xicocaio
 @diditforlulz273 @liorcohen5 @ManifoldFR @mloo3 @SwamyDev @wmmc88 @megan-klaiber @thisray
 @tfederico @hn2 @LucasAlegre @AptX395 @zampanteymedio @decodyng @ardabbour @lorenz-h @mschweizer @lorepieri8
-@ShangqunYu @PierreExeter @JacopoPan @ltbd78
+@ShangqunYu @PierreExeter @JacopoPan @ltbd78 @tom-doerr


### PR DESCRIPTION
## Description
This makes the command work in Zsh.

## Motivation and Context
Command fails if package is not in quotation marks:
```
➜  stable-baselines3 git:(fix_extra_install_command) ✗ pip install stable-baselines3[extra]  
zsh: no matches found: stable-baselines3[extra]
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (update in the documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
- [x] I have reformatted the code using `make format` (**required**)
- [ ] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [ ] I have ensured `make pytest` and `make type` both pass. (**required**)
- [x] I have checked that the documentation builds using `make doc` (**required**)

Note: You can run most of the checks using `make commit-checks`.

Note: we are using a maximum length of 127 characters per line

<!--- This Template is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->
