### PR TITLE
increase default ppo batch size from 64 to 256

### DIFF
--- a/stable_baselines3/ppo/ppo.py
+++ b/stable_baselines3/ppo/ppo.py
@@ -71,7 +71,7 @@ class PPO(OnPolicyAlgorithm):
         env: Union[GymEnv, str],
         learning_rate: Union[float, Schedule] = 3e-4,
         n_steps: int = 2048,
-        batch_size: Optional[int] = 64,
+        batch_size: Optional[int] = 256,
         n_epochs: int = 10,
         gamma: float = 0.99,
         gae_lambda: float = 0.95,


### PR DESCRIPTION
PPO can work poorly with small batch sizes, so 256 is probably a better default for people than 64. Also, 256 is the old default batch size in the original stable baselines (https://github.com/DLR-RM/stable-baselines3/issues/90#issuecomment-742525593), as well SAC currently.

I thought this was a minor enough change not to require the normal PR process. But let me know if you want me to go through that.