### PR TITLE
VecNormalize: allow non-continuous observations when norm_obs is False

### DIFF
--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -18,6 +18,8 @@ New Features:
 Bug Fixes:
 ^^^^^^^^^^
 - Fixed ``dtype`` of observations for ``SimpleMultiObsEnv``
+- Allow `VecNormalize` to wrap discrete-observation environments to normalize reward
+  when observation normalization is disabled.
 
 Deprecations:
 ^^^^^^^^^^^^^

--- a/stable_baselines3/common/vec_env/vec_normalize.py
+++ b/stable_baselines3/common/vec_env/vec_normalize.py
@@ -39,9 +39,10 @@ class VecNormalize(VecEnvWrapper):
     ):
         VecEnvWrapper.__init__(self, venv)
 
-        assert isinstance(
-            self.observation_space, (gym.spaces.Box, gym.spaces.Dict)
-        ), "VecNormalize only support `gym.spaces.Box` and `gym.spaces.Dict` observation spaces"
+        if norm_obs:
+            if not isinstance(self.observation_space, (gym.spaces.Box, gym.spaces.Dict)):
+                raise ValueError("VecNormalize only supports `gym.spaces.Box` and "
+                                 "`gym.spaces.Dict` observation spaces")
 
         if isinstance(self.observation_space, gym.spaces.Dict):
             self.obs_keys = set(self.observation_space.spaces.keys())

--- a/stable_baselines3/common/vec_env/vec_normalize.py
+++ b/stable_baselines3/common/vec_env/vec_normalize.py
@@ -41,8 +41,7 @@ class VecNormalize(VecEnvWrapper):
 
         if norm_obs:
             if not isinstance(self.observation_space, (gym.spaces.Box, gym.spaces.Dict)):
-                raise ValueError("VecNormalize only supports `gym.spaces.Box` and "
-                                 "`gym.spaces.Dict` observation spaces")
+                raise ValueError("VecNormalize only supports `gym.spaces.Box` and `gym.spaces.Dict` observation spaces")
 
         if isinstance(self.observation_space, gym.spaces.Dict):
             self.obs_keys = set(self.observation_space.spaces.keys())

--- a/tests/test_vec_normalize.py
+++ b/tests/test_vec_normalize.py
@@ -142,7 +142,7 @@ def _make_warmstart(env_fn, **kwargs):
     return venv
 
 
-def _make_warmstart_frozenlake(**kwargs):
+def _make_warmstart_cliffwalking(**kwargs):
     """Warm-start VecNormalize by stepping through CliffWalking"""
     return _make_warmstart(lambda: gym.make("CliffWalking-v0"), **kwargs)
 
@@ -354,7 +354,7 @@ def test_sync_vec_normalize(make_env):
 
 def test_discrete_obs():
     with pytest.raises(ValueError, match=".*only supports.*"):
-        _make_warmstart_frozenlake()
+        _make_warmstart_cliffwalking()
 
     # Smoke test that it runs with norm_obs False
-    _make_warmstart_frozenlake(norm_obs=False)
+    _make_warmstart_cliffwalking(norm_obs=False)

--- a/tests/test_vec_normalize.py
+++ b/tests/test_vec_normalize.py
@@ -356,4 +356,5 @@ def test_discrete_obs():
     with pytest.raises(ValueError, match=".*only supports.*"):
         _make_warmstart_frozenlake()
 
-    venv = _make_warmstart_frozenlake(norm_obs=False)
+    # Smoke test that it runs with norm_obs False
+    _make_warmstart_frozenlake(norm_obs=False)

--- a/tests/test_vec_normalize.py
+++ b/tests/test_vec_normalize.py
@@ -143,8 +143,8 @@ def _make_warmstart(env_fn, **kwargs):
 
 
 def _make_warmstart_frozenlake(**kwargs):
-    """Warm-start VecNormalize by stepping through FrozenLake"""
-    return _make_warmstart(lambda: gym.make("FrozenLake-v1"), **kwargs)
+    """Warm-start VecNormalize by stepping through CliffWalking"""
+    return _make_warmstart(lambda: gym.make("CliffWalking-v0"), **kwargs)
 
 
 def _make_warmstart_cartpole():

--- a/tests/test_vec_normalize.py
+++ b/tests/test_vec_normalize.py
@@ -129,10 +129,10 @@ def check_vec_norm_equal(norma, normb):
     assert norma.training == normb.training
 
 
-def _make_warmstart_cartpole():
-    """Warm-start VecNormalize by stepping through CartPole"""
-    venv = DummyVecEnv([lambda: gym.make("CartPole-v1")])
-    venv = VecNormalize(venv)
+def _make_warmstart(env_fn, **kwargs):
+    """Warm-start VecNormalize by stepping through 100 actions."""
+    venv = DummyVecEnv([env_fn])
+    venv = VecNormalize(venv, **kwargs)
     venv.reset()
     venv.get_original_obs()
 
@@ -140,19 +140,21 @@ def _make_warmstart_cartpole():
         actions = [venv.action_space.sample()]
         venv.step(actions)
     return venv
+
+
+def _make_warmstart_frozenlake(**kwargs):
+    """Warm-start VecNormalize by stepping through FrozenLake"""
+    return _make_warmstart(lambda: gym.make("FrozenLake-v1"), **kwargs)
+
+
+def _make_warmstart_cartpole():
+    """Warm-start VecNormalize by stepping through CartPole"""
+    return _make_warmstart(lambda: gym.make("CartPole-v1"))
 
 
 def _make_warmstart_dict_env():
     """Warm-start VecNormalize by stepping through BitFlippingEnv"""
-    venv = DummyVecEnv([make_dict_env])
-    venv = VecNormalize(venv)
-    venv.reset()
-    venv.get_original_obs()
-
-    for _ in range(100):
-        actions = [venv.action_space.sample()]
-        venv.step(actions)
-    return venv
+    return _make_warmstart(make_dict_env)
 
 
 def test_runningmeanstd():
@@ -348,3 +350,10 @@ def test_sync_vec_normalize(make_env):
     # Now they must be synced
     assert allclose(obs, eval_env.normalize_obs(original_obs))
     assert allclose(env.normalize_reward(dummy_rewards), eval_env.normalize_reward(dummy_rewards))
+
+
+def test_discrete_obs():
+    with pytest.raises(ValueError, match=".*only supports.*"):
+        _make_warmstart_frozenlake()
+
+    venv = _make_warmstart_frozenlake(norm_obs=False)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently `VecNormalize` raises an error when attempting to wrap an environment with an observation space that is not `gym.spaces.Box`. This PR applies this check only when `norm_obs` is `True`, and adds a test for `VecNormalize` in a discrete-observation environment.

## Motivation and Context

Some use cases have `VecNormalize` used just for normalizing reward. This should be possible in all environments, regardless of the observation.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**)
- [X] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [X] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [X] I have reformatted the code using `make format` (**required**)
- [X] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [X] I have ensured `make pytest` and `make type` both pass. (**required**)
- [X] I have checked that the documentation builds using `make doc` (**required**)