### PR TITLE
[HOTFIX] Put gym deprecation in correct part of changelog

### DIFF
--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -24,6 +24,7 @@ Bug Fixes:
 
 Deprecations:
 ^^^^^^^^^^^^^
+- Switched minimum Gym version to 0.21.0.
 
 Others:
 ^^^^^^^
@@ -119,7 +120,6 @@ Release 1.3.0 (2021-10-23)
 
 Breaking Changes:
 ^^^^^^^^^^^^^^^^^
-- Support for Python 3.6 was removed.
 - ``sde_net_arch`` argument in policies is deprecated and will be removed in a future version.
 - ``_get_latent`` (``ActorCriticPolicy``) was removed
 - All logging keys now use underscores instead of spaces (@timokau). Concretely this changes:
@@ -147,7 +147,6 @@ Bug Fixes:
 
 Deprecations:
 ^^^^^^^^^^^^^
-- Switched minimum Gym version to 0.21.0.
 
 Others:
 ^^^^^^^


### PR DESCRIPTION
I missed that https://github.com/DLR-RM/stable-baselines3/pull/734 documented the deprecation of gym <=0.20 in release 1.30 not release 1.41a0 as it should be -- hotfix to fix that.