### PR TITLE
Fixed a bug in StackedDictObservations and StackedObservations

### DIFF
--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -25,6 +25,7 @@ SB3-Contrib
 Bug Fixes:
 ^^^^^^^^^^
 - Fixed a bug in ``VecMonitor``. The monitor did not consider the ``info_keywords`` during stepping (@ScheiklP)
+- Fixed a bug in ``StackedDictObservations`` and ``StackedObservations``. Scalar box observations led to incorrect identification of ``stack_ax_size``. Previous version led to stack with ``num_envs`` (@ScheiklP)
 - Fixed a bug in ``HumanOutputFormat``. Distinct keys truncated to the same prefix would overwrite each others value,
   resulting in only one being output. This now raises an error (this should only affect a small fraction of use cases
   with very long keys.)

--- a/stable_baselines3/common/vec_env/stacked_observations.py
+++ b/stable_baselines3/common/vec_env/stacked_observations.py
@@ -157,7 +157,7 @@ class StackedObservations(object):
                 # Expand observations[key] for (num_envs,) to (num_envs, 1)
                 self.stackedobs[..., -observations.shape[self.stack_dimension] :] = observations[:, None]
             else:
-                self.stackedobs[..., -observations.shape[self.stack_dimension]:] = observations
+                self.stackedobs[..., -observations.shape[self.stack_dimension] :] = observations
         return self.stackedobs, infos
 
 

--- a/stable_baselines3/common/vec_env/stacked_observations.py
+++ b/stable_baselines3/common/vec_env/stacked_observations.py
@@ -123,6 +123,9 @@ class StackedObservations(object):
             if done:
                 if "terminal_observation" in infos[i]:
                     old_terminal = infos[i]["terminal_observation"]
+                    # Make sure that the terminal observation from the environment
+                    # as array_like so it can be concatenated by numpy.
+                    # If it is not (e.g. a single float) it will be put into a list.
                     if not hasattr(old_terminal, "__len__"):
                         old_terminal = [old_terminal]
                     if self.channels_first:

--- a/stable_baselines3/common/vec_env/stacked_observations.py
+++ b/stable_baselines3/common/vec_env/stacked_observations.py
@@ -123,6 +123,8 @@ class StackedObservations(object):
             if done:
                 if "terminal_observation" in infos[i]:
                     old_terminal = infos[i]["terminal_observation"]
+                    if not hasattr(old_terminal, "__len__"):
+                        old_terminal = [old_terminal]
                     if self.channels_first:
                         new_terminal = np.concatenate(
                             (self.stackedobs[i, :-stack_ax_size, ...], old_terminal),
@@ -240,6 +242,8 @@ class StackedDictObservations(StackedObservations):
                 if done:
                     if "terminal_observation" in infos[i]:
                         old_terminal = infos[i]["terminal_observation"][key]
+                        if not hasattr(old_terminal, "__len__"):
+                            old_terminal = [old_terminal]
                         if self.channels_first[key]:
                             new_terminal = np.vstack(
                                 (

--- a/stable_baselines3/common/vec_env/stacked_observations.py
+++ b/stable_baselines3/common/vec_env/stacked_observations.py
@@ -100,7 +100,11 @@ class StackedObservations(object):
         if self.channels_first:
             self.stackedobs[:, -observation.shape[self.stack_dimension] :, ...] = observation
         else:
-            self.stackedobs[..., -observation.shape[self.stack_dimension] :] = observation
+            if len(obs.shape) == 1:
+                # Expand observations[key] for (num_envs,) to (num_envs, 1)
+                self.stackedobs[..., -observation[:, None].shape[self.stack_dimension] :] = observation[:, None]
+            else:
+                self.stackedobs[..., -observation.shape[self.stack_dimension] :] = observation
         return self.stackedobs
 
     def update(
@@ -228,7 +232,11 @@ class StackedDictObservations(StackedObservations):
             if self.channels_first[key]:
                 self.stackedobs[key][:, -obs.shape[self.stack_dimension[key]] :, ...] = obs
             else:
-                self.stackedobs[key][..., -obs.shape[self.stack_dimension[key]] :] = obs
+                if len(obs.shape) == 1:
+                    # Expand observations[key] for (num_envs,) to (num_envs, 1)
+                    self.stackedobs[key][..., -obs[:, None].shape[self.stack_dimension[key]] :] = obs[:, None]
+                else:
+                    self.stackedobs[key][..., -obs.shape[self.stack_dimension[key]] :] = obs
         return self.stackedobs
 
     def update(

--- a/tests/test_vec_frame_stack.py
+++ b/tests/test_vec_frame_stack.py
@@ -1,0 +1,111 @@
+import numpy as np
+from gym import spaces
+
+from stable_baselines3.common.vec_env.vec_frame_stack import VecFrameStack
+
+
+class BoxObsVecEnv:
+    """Custom Environment that produces box observations"""
+
+    metadata = {"render.modes": ["human"]}
+
+    def __init__(self, obs_space: spaces.Box):
+        self.num_envs = 4
+        self.action_space = spaces.Discrete(2)
+        self.observation_space = obs_space
+
+    def step_async(self, actions):
+        self.actions = actions
+
+    def step_wait(self):
+        obs = np.zeros((self.num_envs,) + self.observation_space.shape)
+        terminal_obs = np.zeros(self.observation_space.shape)
+        return (
+            obs,
+            np.zeros((self.num_envs,)),
+            np.ones((self.num_envs,), dtype=bool),
+            [{"terminal_observation": terminal_obs} for _ in range(self.num_envs)],
+        )
+
+    def reset(self):
+        return np.zeros((self.num_envs,) + self.observation_space.shape)
+
+    def render(self, mode="human", close=False):
+        pass
+
+
+class DictObsVecEnv:
+    """Custom Environment that produces observation in a dictionary like the procgen env"""
+
+    metadata = {"render.modes": ["human"]}
+
+    def __init__(self):
+        self.num_envs = 4
+        self.action_space = spaces.Discrete(2)
+        self.observation_space = spaces.Dict(
+            {
+                "rgb": spaces.Box(low=0, high=255, shape=(86, 86, 3), dtype=np.uint8),
+                "scalar": spaces.Box(low=0.0, high=1.0, shape=(1,), dtype=np.float32),
+            }
+        )
+
+    def step_async(self, actions):
+        self.actions = actions
+
+    def step_wait(self):
+        obs = {
+            "rgb": np.zeros((self.num_envs, 86, 86, 3)),
+            "scalar": np.zeros((self.num_envs,)),
+        }
+        terminal_obs = {"rgb": np.zeros((86, 86, 3)), "scalar": np.zeros((1,))}
+        return (
+            obs,
+            np.zeros((self.num_envs,)),
+            np.ones((self.num_envs,), dtype=bool),
+            [{"terminal_observation": terminal_obs} for _ in range(self.num_envs)],
+        )
+
+    def reset(self):
+        return {
+            "rgb": np.zeros((self.num_envs, 86, 86, 3)),
+            "scalar": np.zeros((self.num_envs,)),
+        }
+
+    def render(self, mode="human", close=False):
+        pass
+
+
+def test_scalar_frame_stack():
+    obs_space = spaces.Box(low=0.0, high=1.0, shape=(1,), dtype=np.float32)
+    env = BoxObsVecEnv(obs_space)
+    env = VecFrameStack(env, n_stack=8)
+    obs, _, _, _ = env.step(env.action_space.sample())
+
+    assert len(obs) == 4
+    assert obs[0].shape == (8,)
+
+
+def test_dict_frame_stack():
+    env = DictObsVecEnv()
+    env = VecFrameStack(env, n_stack=8)
+    obs, _, _, _ = env.step(env.action_space.sample())
+
+    assert obs["rgb"].shape == (4, 86, 86, 8 * 3)
+    assert obs["scalar"].shape == (4, 8)
+
+
+def test_regular_frame_stack():
+    obs_space_0 = spaces.Box(low=0.0, high=1.0, shape=(86, 86, 3), dtype=np.float32)
+    obs_space_1 = spaces.Box(low=0.0, high=1.0, shape=(6,), dtype=np.float32)
+
+    env_0 = BoxObsVecEnv(obs_space_0)
+    env_0 = VecFrameStack(env_0, n_stack=8)
+    obs_0, _, _, _ = env_0.step(env_0.action_space.sample())
+    assert len(obs_0) == 4
+    assert obs_0[0].shape == (86, 86, 3 * 8)
+
+    env_1 = BoxObsVecEnv(obs_space_1)
+    env_1 = VecFrameStack(env_1, n_stack=8)
+    obs_1, _, _, _ = env_1.step(env_1.action_space.sample())
+    assert len(obs_1) == 4
+    assert obs_1[0].shape == (8 * 6,)

--- a/tests/test_vec_frame_stack.py
+++ b/tests/test_vec_frame_stack.py
@@ -4,6 +4,36 @@ from gym import spaces
 from stable_baselines3.common.vec_env.vec_frame_stack import VecFrameStack
 
 
+class ScalarObsVecEnv:
+    """Custom Environment that produces box observations"""
+
+    metadata = {"render.modes": ["human"]}
+
+    def __init__(self):
+        self.num_envs = 4
+        self.action_space = spaces.Discrete(2)
+        self.observation_space = spaces.Box(low=0.0, high=1.0, shape=(1,), dtype=np.float32)
+
+    def step_async(self, actions):
+        self.actions = actions
+
+    def step_wait(self):
+        obs = np.zeros((self.num_envs,) + self.observation_space.shape)
+        terminal_obs = 0.0
+        return (
+            obs,
+            np.zeros((self.num_envs,)),
+            np.ones((self.num_envs,), dtype=bool),
+            [{"terminal_observation": terminal_obs} for _ in range(self.num_envs)],
+        )
+
+    def reset(self):
+        return np.zeros((self.num_envs,) + self.observation_space.shape)
+
+    def render(self, mode="human", close=False):
+        pass
+
+
 class BoxObsVecEnv:
     """Custom Environment that produces box observations"""
 
@@ -57,7 +87,7 @@ class DictObsVecEnv:
             "rgb": np.zeros((self.num_envs, 86, 86, 3)),
             "scalar": np.zeros((self.num_envs,)),
         }
-        terminal_obs = {"rgb": np.zeros((86, 86, 3)), "scalar": np.zeros((1,))}
+        terminal_obs = {"rgb": np.zeros((86, 86, 3)), "scalar": 0.0}
         return (
             obs,
             np.zeros((self.num_envs,)),
@@ -76,8 +106,7 @@ class DictObsVecEnv:
 
 
 def test_scalar_frame_stack():
-    obs_space = spaces.Box(low=0.0, high=1.0, shape=(1,), dtype=np.float32)
-    env = BoxObsVecEnv(obs_space)
+    env = ScalarObsVecEnv()
     env = VecFrameStack(env, n_stack=8)
     obs, _, _, _ = env.step(env.action_space.sample())
 


### PR DESCRIPTION
Fix for bug described in https://github.com/DLR-RM/stable-baselines3/issues/805

## Description
Added a simple check to make sure the `terminal_observation` is array_like.
If not, creates a list with the `terminal_observation` inside, so that numpy's concatenate works again.

## Motivation and Context
- [x] I have raised an issue to propose this change ([required](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) for new features and bug fixes)

closes #805 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [x] I have reformatted the code using `make format` (**required**)
- [x] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [x] I have ensured `make pytest` and `make type` both pass. (**required**)
- [x] I have checked that the documentation builds using `make doc` (**required**)

