### PR TITLE
Compatibility with new Numpy Random Generator

### DIFF
--- a/stable_baselines3/common/atari_wrappers.py
+++ b/stable_baselines3/common/atari_wrappers.py
@@ -33,7 +33,10 @@ class NoopResetEnv(gym.Wrapper):
         if self.override_num_noops is not None:
             noops = self.override_num_noops
         else:
-            noops = self.unwrapped.np_random.randint(1, self.noop_max + 1)
+            if hasattr(self.unwrapped.np_random, 'randint'):
+                noops = self.unwrapped.np_random.randint(1, self.noop_max + 1)
+            else:
+                noops = self.unwrapped.np_random.integers(1, self.noop_max + 1)
         assert noops > 0
         obs = np.zeros(0)
         for _ in range(noops):


### PR DESCRIPTION
np_random.randint calls a legacy method which causes an AttributeError because gym uses the new numpy Random Generator that does not have a randint method.
Legacy Generator: https://numpy.org/doc/stable/reference/random/generated/numpy.random.RandomState.randint.html
New Generator that is used by gym: https://numpy.org/doc/stable/reference/random/generated/numpy.random.Generator.integers.html
Quote: "New code should use the integers method of a default_rng() instance instead; please see the Quick Start."

<img width="852" alt="Screenshot 2022-04-26 at 16 36 45" src="https://user-images.githubusercontent.com/50620424/165325173-51de40b2-6559-470c-8743-606e447b79dd.png">