### PR TITLE
Add doc to use mlflow logger

### DIFF
--- a/docs/guide/integrations.rst
+++ b/docs/guide/integrations.rst
@@ -137,3 +137,56 @@ Then, in this example, we train a PPO agent to play CartPole-v1 and push it to a
       filename="ppo-CartPole-v1",
       commit_message="Added Cartpole-v1 model trained with PPO",
   )
+
+MLFLow
+======
+
+If you want to use `MLFLow <https://github.com/mlflow/mlflow>`_ to track your SB3 experiments,
+you can adapt the following code which defines a custom logger output:
+
+.. code-block:: python
+
+  import sys
+  from typing import Any, Dict, Tuple, Union
+
+  import mlflow
+  import numpy as np
+
+  from stable_baselines3 import SAC
+  from stable_baselines3.common.logger import HumanOutputFormat, KVWriter, Logger
+
+
+  class MLflowOutputFormat(KVWriter):
+      """
+      Dumps key/value pairs into MLflow's numeric format.
+      """
+
+      def write(
+          self,
+          key_values: Dict[str, Any],
+          key_excluded: Dict[str, Union[str, Tuple[str, ...]]],
+          step: int = 0,
+      ) -> None:
+
+          for (key, value), (_, excluded) in zip(
+              sorted(key_values.items()), sorted(key_excluded.items())
+          ):
+
+              if excluded is not None and "mlflow" in excluded:
+                  continue
+
+              if isinstance(value, np.ScalarType):
+                  if not isinstance(value, str):
+                      mlflow.log_metric(key, value, step)
+
+
+  loggers = Logger(
+      folder=None,
+      output_formats=[HumanOutputFormat(sys.stdout), MLflowOutputFormat()],
+  )
+
+  with mlflow.start_run():
+      model = SAC("MlpPolicy", "Pendulum-v1", verbose=2)
+      # Set custom logger
+      model.set_logger(loggers)
+      model.learn(total_timesteps=10000, log_interval=1)

--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -37,6 +37,7 @@ Documentation:
 ^^^^^^^^^^^^^^
 - Added link to gym doc and gym env checker
 - Fix typo in PPO doc (@bcollazo)
+- Added doc about MLFlow integration via custom logger (@git-thor)
 
 
 Release 1.5.0 (2022-03-25)
@@ -966,4 +967,4 @@ And all the contributors:
 @wkirgsn @AechPro @CUN-bjy @batu @IljaAvadiev @timokau @kachayev @cleversonahum
 @eleurent @ac-93 @cove9988 @theDebugger811 @hsuehch @Demetrio92 @thomasgubler @IperGiove @ScheiklP
 @simoninithomas @armandpl @manuel-delverme @Gautam-J @gianlucadecola @buoyancy99 @caburu @xy9485
-@Gregwar @ycheng517 @quantitative-technologies @bcollazo
+@Gregwar @ycheng517 @quantitative-technologies @bcollazo @git-thor

--- a/stable_baselines3/common/logger.py
+++ b/stable_baselines3/common/logger.py
@@ -17,11 +17,6 @@ try:
 except ImportError:
     SummaryWriter = None
 
-try:
-    import mlflow
-except ImportError:
-    mlflow = None
-
 
 DEBUG = 10
 INFO = 20
@@ -252,12 +247,13 @@ def filter_excluded_keys(
 
 
 class JSONOutputFormat(KVWriter):
-    def __init__(self, filename: str):
-        """
-        log to a file, in the JSON format
+    """
+    Log to a file, in the JSON format
 
-        :param filename: the file to write the log to
-        """
+    :param filename: the file to write the log to
+    """
+
+    def __init__(self, filename: str):
         self.file = open(filename, "wt")
 
     def write(self, key_values: Dict[str, Any], key_excluded: Dict[str, Union[str, Tuple[str, ...]]], step: int = 0) -> None:
@@ -293,13 +289,13 @@ class JSONOutputFormat(KVWriter):
 
 
 class CSVOutputFormat(KVWriter):
+    """
+    Log to a file, in a CSV format
+
+    :param filename: the file to write the log to
+    """
+
     def __init__(self, filename: str):
-        """
-        log to a file, in a CSV format
-
-        :param filename: the file to write the log to
-        """
-
         self.file = open(filename, "w+t")
         self.keys = []
         self.separator = ","
@@ -357,12 +353,13 @@ class CSVOutputFormat(KVWriter):
 
 
 class TensorBoardOutputFormat(KVWriter):
-    def __init__(self, folder: str):
-        """
-        Dumps key/value pairs into TensorBoard's numeric format.
+    """
+    Dumps key/value pairs into TensorBoard's numeric format.
 
-        :param folder: the folder to write the log to
-        """
+    :param folder: the folder to write the log to
+    """
+
+    def __init__(self, folder: str):
         assert SummaryWriter is not None, "tensorboard is not installed, you can use " "pip install tensorboard to do so"
         self.writer = SummaryWriter(log_dir=folder)
 
@@ -404,42 +401,6 @@ class TensorBoardOutputFormat(KVWriter):
             self.writer = None
 
 
-class MLflowOutputFormat(KVWriter):
-    def __init__(self):
-        """
-        Dumps key/value pairs into MLflow's numeric format.
-        """
-        assert mlflow is not None, "mlflow is not installed, you can use " "pip install mlflow to do so"
-
-    def write(self, key_values: Dict[str, Any], key_excluded: Dict[str, Union[str, Tuple[str, ...]]], step: int = 0) -> None:
-
-        print("Write")
-
-        for (key, value), (_, excluded) in zip(sorted(key_values.items()), sorted(key_excluded.items())):
-
-            if excluded is not None and "mlflow" in excluded:
-                continue
-
-            if isinstance(value, np.ScalarType):
-                if isinstance(value, str):
-                    # str is considered a np.ScalarType
-                    pass
-                else:
-                    mlflow.log_metric(key, value, step)
-
-            if isinstance(value, th.Tensor):
-                pass
-
-            if isinstance(value, Video):
-                pass
-
-            if isinstance(value, Figure):
-                pass
-
-            if isinstance(value, Image):
-                pass
-
-
 def make_output_format(_format: str, log_dir: str, log_suffix: str = "") -> KVWriter:
     """
     return a logger for the requested format
@@ -460,8 +421,6 @@ def make_output_format(_format: str, log_dir: str, log_suffix: str = "") -> KVWr
         return CSVOutputFormat(os.path.join(log_dir, f"progress{log_suffix}.csv"))
     elif _format == "tensorboard":
         return TensorBoardOutputFormat(log_dir)
-    elif _format == "mlflow":
-        return MLflowOutputFormat()
     else:
         raise ValueError(f"Unknown format specified: {_format}")
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR adds the feature to log with MLflow via similar configuration like the TensorBoard logger.

The PR partly addresses the discussion in #428, especially the request regarding planned support of MLflow as logging framework by @EloyAnguiano.

## Description

MLflow logging can be implemented like TensorBoard extended the logger module `stabel_baselines3.common.logger`. Thereby, the following changes are proposed and implemented:

- [x] Try `mlflow` import if installed, otherwise return a `None` module which is asserted against, later on.
- [x] Extend ` make_output_format` function with `mlflow` format string, returning a class instance of the MLflow output format
- [x] Add the `MLflowOutputFormat` class with similar API like the `TensorBoardOutputFormat`, supporting scalar number metric logging per step.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->
- [x] ~~I have raised an issue to propose this change ([required](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) for new features and bug fixes)~~ I have raised an issue comment on #428 to propose the change and provide a working example with the issue.

[mlflow/MLflow](https://github.com/mlflow/mlflow) competes in the tracking tool and framework ecosystem with TensorBoard, Weights&Biases or comet-ml. Though, it is an independent and open-source tracking tool with an active community. MLflow has gained track during the last year and proven to be a suitable tracking tool for ML and RL applications. One key point of MLflow are features around project and models tracking as well as producing reproducible ML environments, ready to deploy when switching machines. This makes it an interesting choice for ML research.

I am NOT affiliated with MLflow, nor a contributor to MLflow and therefore not do not have conflicting interests.

Stable Baselines3 does currently not easily support tracking via MLflow due to the encapsuled train methods and metric logging inside model instances. Accessing these parameters is possible, but not as easy as using one of the built-in loggers, like TensorFlow. However, MLflow has its advantages and similar behavior like TensorFlow, so an extension of the SB3 logger module is possible and non-breaking, while providing benefits and enabling another practical use-case for SB3.

The implementation details have been described, above. Limitations are pointed out in the subsequent section.

Please refer to an external implementation variant in #428 that has now been directly implemented to SB3 in this PR. Attached, you'll find a short example for using the logger extension as well as the successful tracking to the MLFlow GUI. The example below will be part of the documentation update.

```py
import gym
import mlflow  # pip install mlflow
import numpy as np

from stable_baselines3 import SAC
from stable_baselines3.common.logger import configure

loggers = configure(folder=None, format_strings=["stdout", "mlflow"])
env = gym.make("Pendulum-v1")

with mlflow.start_run():
    model = SAC("MlpPolicy", env, verbose=2)
    model.set_logger(loggers)
    model.learn(total_timesteps=10000, log_interval=1)
```

<img width="20%" src="https://user-images.githubusercontent.com/62146721/165409887-35dd60cc-6d53-4570-b47a-fba7ff4adef8.png">
<img width="75%" src="https://user-images.githubusercontent.com/62146721/165409737-6da77525-1d90-45ac-9f4e-0a914c28fea4.png">


## Limitations

MLflow does not easily support asset logging like figures, images, videos in comparison to TensorBoard. Accordingly, these types are passed. Work-arounds are possible, but not necessary or wanted due to less supported dependencies. Compare `mlflow-extend` library for further asset types. Also, a workaround through temporary save and upload assets as mlflow artifact is possible.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation (update in the documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**)
- [ ] I have updated the changelog accordingly (**required**).
- [x] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [ ] I have reformatted the code using `make format` (**required**)
- [ ] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [ ] I have ensured `make pytest` and `make type` both pass. (**required**)
- [ ] I have checked that the documentation builds using `make doc` (**required**)

<!--- Note: You can run most of the checks using `make commit-checks`. -->

<!--- Note: we are using a maximum length of 127 characters per line -->

<!--- This Template is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->
