### PR TITLE
Curriculum learning in custom env support.

### DIFF
--- a/stable_baselines3/common/on_policy_algorithm.py
+++ b/stable_baselines3/common/on_policy_algorithm.py
@@ -288,7 +288,7 @@ class OnPolicyAlgorithm(BaseAlgorithm):
 
         callback.on_training_end()
 
-        return self
+        return self6
 
     def _get_torch_save_params(self) -> Tuple[List[str], List[str]]:
         state_dicts = ["policy", "policy.optimizer"]

--- a/stable_baselines3/common/on_policy_algorithm.py
+++ b/stable_baselines3/common/on_policy_algorithm.py
@@ -288,7 +288,7 @@ class OnPolicyAlgorithm(BaseAlgorithm):
 
         callback.on_training_end()
 
-        return self6
+        return self
 
     def _get_torch_save_params(self) -> Tuple[List[str], List[str]]:
         state_dicts = ["policy", "policy.optimizer"]

--- a/stable_baselines3/common/on_policy_algorithm.py
+++ b/stable_baselines3/common/on_policy_algorithm.py
@@ -222,6 +222,24 @@ class OnPolicyAlgorithm(BaseAlgorithm):
         """
         raise NotImplementedError
 
+    def processPerLearningIteration(self, iteration:int, meanReward:float, logger) -> None:
+        """
+        Custom process per learning iteration.
+        Redefine this to let you have your own process per 
+        learning iteration like curriculum learning 
+        or logger something you need.
+        example:
+
+        def processPerLearningIteration(iteration:int, meanReward:float, logger) -> None:
+            print('Testing iteration:%d'%iteration)
+            print('Testing reward:%f'%meanReward)
+
+        model = PPO(...)
+        model.processPerLearningIteration = processPerLearningIteration
+        model.learn(...)
+        """
+        pass
+
     def learn(
         self,
         total_timesteps: int,
@@ -263,6 +281,8 @@ class OnPolicyAlgorithm(BaseAlgorithm):
                 self.logger.record("time/time_elapsed", int(time.time() - self.start_time), exclude="tensorboard")
                 self.logger.record("time/total_timesteps", self.num_timesteps, exclude="tensorboard")
                 self.logger.dump(step=self.num_timesteps)
+
+            self.processPerLearningIteration(iteration, safe_mean([ep_info["r"] for ep_info in self.ep_info_buffer]), self.logger)
 
             self.train()
 


### PR DESCRIPTION
Custom process per learning iteration

## Description
Define a nothing to do function that call at each learning it, redefine it to let user have their own process per learning iteration like curriculum learning or logger something they need.
For me I need to change some parameters to unity env during some specify training stage. by using this, I can simply do that.

```
def processPerLearningIteration(iteration:int, meanReward:float, logger) -> None:
    print('Testing iteration:%d'%iteration)
    print('Testing reward:%f'%meanReward)

model = PPO(...)
model.processPerLearningIteration = processPerLearningIteration
model.learn(...)
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [ ] I have reformatted the code using `make format` (**required**)
- [ ] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [ ] I have ensured `make pytest` and `make type` both pass. (**required**)
- [ ] I have checked that the documentation builds using `make doc` (**required**)

Note: You can run most of the checks using `make commit-checks`.

Note: we are using a maximum length of 127 characters per line

<!--- This Template is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->
