### PR TITLE
Fix url in docs

### DIFF
--- a/docs/guide/install.rst
+++ b/docs/guide/install.rst
@@ -60,7 +60,7 @@ Bleeding-edge version
 
 	.. code-block:: bash
 
-		pip install git+https://github.com/carlosluis/stable-baselines3/tree/fix_tests
+		pip install git+https://github.com/carlosluis/stable-baselines3@fix_tests
 
   See `PR #780 <https://github.com/DLR-RM/stable-baselines3/pull/780>`_ for more information.
 

--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -31,6 +31,7 @@ Documentation:
 - Fixed typo in docstring "nature" -> "Nature" (@Melanol)
 - Added info on split tensorboard logs into (@Melanol)
 - Fixed typo in ppo doc (@francescoluciano)
+- Fixed typo in install doc(@jlp-ue)
 
 
 Release 1.6.0 (2022-07-11)
@@ -1015,4 +1016,4 @@ And all the contributors:
 @eleurent @ac-93 @cove9988 @theDebugger811 @hsuehch @Demetrio92 @thomasgubler @IperGiove @ScheiklP
 @simoninithomas @armandpl @manuel-delverme @Gautam-J @gianlucadecola @buoyancy99 @caburu @xy9485
 @Gregwar @ycheng517 @quantitative-technologies @bcollazo @git-thor @TibiGG @cool-RR @MWeltevrede
-@Melanol @qgallouedec @francescoluciano
+@Melanol @qgallouedec @francescoluciano @jlp-ue


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

If you want to use sb3 with gym > 0.23 you need to install @carlosluis fork of sb3. 
The github repo link in the docs was wrong. 

## Description

Changed it to 
`pip install git+https://github.com/carlosluis/stable-baselines3@fix_tests`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Closes https://github.com/DLR-RM/stable-baselines3/issues/999

<!--- You can use the syntax `closes #100` if this solves the issue #100 -->
- [x] I have raised an issue to propose this change ([required](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) for new features and bug fixes)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (update in the documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the changelog accordingly (**required**).
- [x] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
- [x] I have reformatted the code using `make format` (**required**)
- [x] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [x] I have ensured `make pytest` and `make type` both pass. (**required**)
- [x] I have checked that the documentation builds using `make doc` (**required**)

Note: You can run most of the checks using `make commit-checks`.
