### PR TITLE
Automatically create missing directories of ``filename``s passed to ``ResultsWriter``

### DIFF
--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -1038,4 +1038,4 @@ And all the contributors:
 @simoninithomas @armandpl @manuel-delverme @Gautam-J @gianlucadecola @buoyancy99 @caburu @xy9485
 @Gregwar @ycheng517 @quantitative-technologies @bcollazo @git-thor @TibiGG @cool-RR @MWeltevrede
 @Melanol @qgallouedec @francescoluciano @jlp-ue @burakdmb @timothe-chaumont @honglu2875
-@anand-bala @hughperkins @sidney-tio @AlexPasqua
+@anand-bala @hughperkins @sidney-tio @AlexPasqua @dominicgkerr

--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -38,8 +38,8 @@ Deprecations:
 Others:
 ^^^^^^^
 - Fixed ``DictReplayBuffer.next_observations`` typing (@qgallouedec)
-
 - Added support for ``device="auto"`` in buffers and made it default (@qgallouedec)
+- Updated ``ResultsWriter` (used internally by ``Monitor`` wrapper) to automatically create missing directories when ``filename`` is a path (@dominicgkerr)
 
 Documentation:
 ^^^^^^^^^^^^^^

--- a/stable_baselines3/common/buffers.py
+++ b/stable_baselines3/common/buffers.py
@@ -574,7 +574,7 @@ class DictReplayBuffer(ReplayBuffer):
         reward: np.ndarray,
         done: np.ndarray,
         infos: List[Dict[str, Any]],
-    ) -> None:
+    ) -> None:  # pytype: disable=signature-mismatch
         # Copy to avoid modification by reference
         for key in self.observations.keys():
             # Reshape needed when using multiple envs with discrete observations
@@ -711,7 +711,7 @@ class DictRolloutBuffer(RolloutBuffer):
         episode_start: np.ndarray,
         value: th.Tensor,
         log_prob: th.Tensor,
-    ) -> None:
+    ) -> None:  # pytype: disable=signature-mismatch
         """
         :param obs: Observation
         :param action: Action

--- a/stable_baselines3/common/monitor.py
+++ b/stable_baselines3/common/monitor.py
@@ -163,9 +163,10 @@ class ResultsWriter:
     """
     A result writer that saves the data from the `Monitor` class
 
-    :param filename: the location to save a log file, can be None for no log
+    :param filename: the location to save a log file. When it does not end in
+        the string ``"monitor.csv"``, this suffix will be appended to it
     :param header: the header dictionary object of the saved csv
-    :param reset_keywords: the extra information to log, typically is composed of
+    :param extra_keys: the extra information to log, typically is composed of
         ``reset_keywords`` and ``info_keywords``
     :param override_existing: appends to file if ``filename`` exists, otherwise
         override existing files (default)

--- a/stable_baselines3/common/monitor.py
+++ b/stable_baselines3/common/monitor.py
@@ -185,6 +185,9 @@ class ResultsWriter:
                 filename = os.path.join(filename, Monitor.EXT)
             else:
                 filename = filename + "." + Monitor.EXT
+        filename = os.path.realpath(filename)
+        # Create (if any) missing filename directories
+        os.makedirs(os.path.dirname(filename), exist_ok=True)
         # Append mode when not overridding existing file
         mode = "w" if override_existing else "a"
         # Prevent newline issue on Windows, see GH issue #692

--- a/stable_baselines3/common/vec_env/stacked_observations.py
+++ b/stable_baselines3/common/vec_env/stacked_observations.py
@@ -199,7 +199,7 @@ class StackedDictObservations(StackedObservations):
             spaces_dict[key] = spaces.Box(low=low, high=high, dtype=subspace.dtype)
         return spaces.Dict(spaces=spaces_dict)
 
-    def reset(self, observation: Dict[str, np.ndarray]) -> Dict[str, np.ndarray]:
+    def reset(self, observation: Dict[str, np.ndarray]) -> Dict[str, np.ndarray]:  # pytype: disable=signature-mismatch
         """
         Resets the stacked observations, adds the reset observation to the stack, and returns the stack
 
@@ -219,7 +219,7 @@ class StackedDictObservations(StackedObservations):
         observations: Dict[str, np.ndarray],
         dones: np.ndarray,
         infos: List[Dict[str, Any]],
-    ) -> Tuple[Dict[str, np.ndarray], List[Dict[str, Any]]]:
+    ) -> Tuple[Dict[str, np.ndarray], List[Dict[str, Any]]]:  # pytype: disable=signature-mismatch
         """
         Adds the observations to the stack and uses the dones to update the infos.
 

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -48,6 +48,15 @@ def test_monitor(tmp_path):
         assert set(last_logline.keys()) == {"l", "t", "r"}, "Incorrect keys in monitor logline"
     os.remove(monitor_file)
 
+    # Check missing filename directories are created
+    monitor_dir = os.path.join(str(tmp_path), "missing-dir")
+    monitor_file = os.path.join(monitor_dir, f"stable_baselines-test-{uuid.uuid4()}.monitor.csv")
+    assert os.path.exists(monitor_dir) is False
+    _ = Monitor(env, monitor_file)
+    assert os.path.exists(monitor_dir) is True
+    os.remove(monitor_file)
+    os.rmdir(monitor_dir)
+
 
 def test_monitor_load_results(tmp_path):
     """


### PR DESCRIPTION
## Description
Two commits fix that `closes #1068`. I added two new lines (189 & 191) changing the logic of `stable_baselines3.common.monitor.ResultsWriter` (the rest of the changes to `monitor.py` are to update the docstring/comments), and added an accompanying unittest (into `test_monitor.py`).


closes #1068 

## Motivation and Context
Before, when a `ResultsWriter` class (i.e. whenever a `stable_baselines3.common.monitor.Monitor` wrapper) is created, a file-handle to the provided `filename` is opened on [line:191](https://github.com/DLR-RM/stable-baselines3/blob/master/stable_baselines3/common/monitor.py#L191). If the `filename` contains any directories  (ether relative or absolute), all its parent directories MUST exists, otherwise a `FileNotFoundError` is raised. To avoid this, I updated `stable_baselines3.common.monitor.ResultsWriter` to resolve the provided `filename` path, and automatically create any missing parent directories. 

If the `filename` is not resolved first, "pure"-filenames (i.e. not relative or absolute paths) will return `''` when passed into `os.path.dirname(filename)`. As `os.makedirs` raises a `FileNotFoundError` on this input, this would additionally have to be wrapped in an if-statement or `or` constructor (so, I argue, it's "nicer" to resolve, than to "handle an edge-case"...)

After looking at the logic in `stable_baselines3.common.env_util.make_vec_env`, I decided I would not to wrap the `os.makedirs(...)` call in an if-statement checking that `filename is not None`. I argue that a `ResultsWriter` created with `filename=None` (which the docstring incorrectly stated a valid input) would be redundant, as "Why create a `ResultsWriter` when you don't want a log?". 

- [X] I have raised an issue to propose this change ([required](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) for new features and bug fixes)

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist:
- [X] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**)
- [X] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [X] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [X] I have reformatted the code using `make format` (**required**)
- [X] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [X] I have ensured `make pytest` and `make type` both pass. (**required**)
- [X] I have checked that the documentation builds using `make doc` (**required**)

Note: You can run most of the checks using `make commit-checks`.

Note: we are using a maximum length of 127 characters per line

<!--- This Template is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->
