### PR TITLE
Update evaluate_policy type annotation to support policies as well as RL algorithms

### DIFF
--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -25,6 +25,7 @@ Bug Fixes:
 - Fix return type of ``evaluate_actions`` in ``ActorCritcPolicy`` to reflect that entropy is an optional tensor (@Rocamonde)
 - Fix type annotation of ``policy`` in ``BaseAlgorithm`` and ``OffPolicyAlgorithm``
 - Allowed model trained with Python 3.7 to be loaded with Python 3.8+ without the ``custom_objects`` workaround
+- Fix type annotation of ``model`` in ``evaluate_policy``
 
 Deprecations:
 ^^^^^^^^^^^^^

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
         "gym==0.21",  # Fixed version due to breaking changes in 0.22
         "numpy",
         "torch>=1.11",
-        "typing_extensions",
+        "typing_extensions>=4.0,<5",
         # For saving models
         "cloudpickle",
         # For reading logs

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ setup(
         "gym==0.21",  # Fixed version due to breaking changes in 0.22
         "numpy",
         "torch>=1.11",
+        "typing_extensions",
         # For saving models
         "cloudpickle",
         # For reading logs

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
         "gym==0.21",  # Fixed version due to breaking changes in 0.22
         "numpy",
         "torch>=1.11",
-        "typing_extensions>=4.0,<5",
+        'typing_extensions>=4.0,<5; python_version < "3.8.0"',
         # For saving models
         "cloudpickle",
         # For reading logs

--- a/stable_baselines3/common/base_class.py
+++ b/stable_baselines3/common/base_class.py
@@ -513,7 +513,7 @@ class BaseAlgorithm(ABC):
 
     def predict(
         self,
-        observation: np.ndarray,
+        observation: Union[np.ndarray, Dict[str, np.ndarray]],
         state: Optional[Tuple[np.ndarray, ...]] = None,
         episode_start: Optional[np.ndarray] = None,
         deterministic: bool = False,

--- a/stable_baselines3/common/evaluation.py
+++ b/stable_baselines3/common/evaluation.py
@@ -4,12 +4,12 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 import gym
 import numpy as np
 
-from stable_baselines3.common import base_class, policies
+from stable_baselines3.common import base_class, type_aliases
 from stable_baselines3.common.vec_env import DummyVecEnv, VecEnv, VecMonitor, is_vecenv_wrapped
 
 
 def evaluate_policy(
-    model: policies.PolicyPredictor,
+    model: "type_aliases.PolicyPredictor",
     env: Union[gym.Env, VecEnv],
     n_eval_episodes: int = 10,
     deterministic: bool = True,

--- a/stable_baselines3/common/evaluation.py
+++ b/stable_baselines3/common/evaluation.py
@@ -4,12 +4,12 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 import gym
 import numpy as np
 
-from stable_baselines3.common import base_class
+from stable_baselines3.common import base_class, policies
 from stable_baselines3.common.vec_env import DummyVecEnv, VecEnv, VecMonitor, is_vecenv_wrapped
 
 
 def evaluate_policy(
-    model: "base_class.BaseAlgorithm",
+    model: policies.PolicyPredictor,
     env: Union[gym.Env, VecEnv],
     n_eval_episodes: int = 10,
     deterministic: bool = True,
@@ -34,7 +34,9 @@ def evaluate_policy(
         results as well. You can avoid this by wrapping environment with ``Monitor``
         wrapper before anything else.
 
-    :param model: The RL agent you want to evaluate.
+    :param model: The RL agent you want to evaluate. This can be any object
+        that implements a `predict` method, such as an RL algorithm (``BaseAlgorithm``)
+        or policy (``BasePolicy``).
     :param env: The gym environment or ``VecEnv`` environment.
     :param n_eval_episodes: Number of episode to evaluate the agent
     :param deterministic: Whether to use deterministic or stochastic actions

--- a/stable_baselines3/common/evaluation.py
+++ b/stable_baselines3/common/evaluation.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 import gym
 import numpy as np
 
-from stable_baselines3.common import base_class, type_aliases
+from stable_baselines3.common import type_aliases
 from stable_baselines3.common.vec_env import DummyVecEnv, VecEnv, VecMonitor, is_vecenv_wrapped
 
 

--- a/stable_baselines3/common/policies.py
+++ b/stable_baselines3/common/policies.py
@@ -4,7 +4,7 @@ import collections
 import copy
 from abc import ABC, abstractmethod
 from functools import partial
-from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar, Union
+from typing import Any, Dict, List, Optional, Protocol, Tuple, Type, TypeVar, Union
 
 import gym
 import numpy as np
@@ -242,6 +242,29 @@ class BaseModel(nn.Module):
 
         observation = obs_as_tensor(observation, self.device)
         return observation, vectorized_env
+
+
+class PolicyPredictor(Protocol):
+    def predict(
+        self,
+        observation: Union[np.ndarray, Dict[str, np.ndarray]],
+        state: Optional[Tuple[np.ndarray, ...]] = None,
+        episode_start: Optional[np.ndarray] = None,
+        deterministic: bool = False,
+    ) -> Tuple[np.ndarray, Optional[Tuple[np.ndarray, ...]]]:
+        """
+        Get the policy action from an observation (and optional hidden state).
+        Includes sugar-coating to handle different observations (e.g. normalizing images).
+
+        :param observation: the input observation
+        :param state: The last hidden states (can be None, used in recurrent policies)
+        :param episode_start: The last masks (can be None, used in recurrent policies)
+            this correspond to beginning of episodes,
+            where the hidden states of the RNN must be reset.
+        :param deterministic: Whether or not to return deterministic actions.
+        :return: the model's action and the next hidden state
+            (used in recurrent policies)
+        """
 
 
 class BasePolicy(BaseModel, ABC):

--- a/stable_baselines3/common/policies.py
+++ b/stable_baselines3/common/policies.py
@@ -4,7 +4,7 @@ import collections
 import copy
 from abc import ABC, abstractmethod
 from functools import partial
-from typing import Any, Dict, List, Optional, Protocol, Tuple, Type, TypeVar, Union
+from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar, Union
 
 import gym
 import numpy as np
@@ -242,29 +242,6 @@ class BaseModel(nn.Module):
 
         observation = obs_as_tensor(observation, self.device)
         return observation, vectorized_env
-
-
-class PolicyPredictor(Protocol):
-    def predict(
-        self,
-        observation: Union[np.ndarray, Dict[str, np.ndarray]],
-        state: Optional[Tuple[np.ndarray, ...]] = None,
-        episode_start: Optional[np.ndarray] = None,
-        deterministic: bool = False,
-    ) -> Tuple[np.ndarray, Optional[Tuple[np.ndarray, ...]]]:
-        """
-        Get the policy action from an observation (and optional hidden state).
-        Includes sugar-coating to handle different observations (e.g. normalizing images).
-
-        :param observation: the input observation
-        :param state: The last hidden states (can be None, used in recurrent policies)
-        :param episode_start: The last masks (can be None, used in recurrent policies)
-            this correspond to beginning of episodes,
-            where the hidden states of the RNN must be reset.
-        :param deterministic: Whether or not to return deterministic actions.
-        :return: the model's action and the next hidden state
-            (used in recurrent policies)
-        """
 
 
 class BasePolicy(BaseModel, ABC):

--- a/stable_baselines3/common/type_aliases.py
+++ b/stable_baselines3/common/type_aliases.py
@@ -1,7 +1,8 @@
 """Common aliases for type hints"""
 
 from enum import Enum
-from typing import Any, Callable, Dict, List, NamedTuple, Optional, Protocol, Tuple, Union
+from typing import Any, Callable, Dict, List, NamedTuple, Optional, Tuple, Union
+from typing_extensions import Protocol
 
 import gym
 import numpy as np

--- a/stable_baselines3/common/type_aliases.py
+++ b/stable_baselines3/common/type_aliases.py
@@ -1,7 +1,7 @@
 """Common aliases for type hints"""
 
 from enum import Enum
-from typing import Any, Callable, Dict, List, NamedTuple, Tuple, Union
+from typing import Any, Callable, Dict, List, NamedTuple, Optional, Protocol, Tuple, Union
 
 import gym
 import numpy as np
@@ -69,3 +69,26 @@ class TrainFrequencyUnit(Enum):
 class TrainFreq(NamedTuple):
     frequency: int
     unit: TrainFrequencyUnit  # either "step" or "episode"
+
+
+class PolicyPredictor(Protocol):
+    def predict(
+        self,
+        observation: Union[np.ndarray, Dict[str, np.ndarray]],
+        state: Optional[Tuple[np.ndarray, ...]] = None,
+        episode_start: Optional[np.ndarray] = None,
+        deterministic: bool = False,
+    ) -> Tuple[np.ndarray, Optional[Tuple[np.ndarray, ...]]]:
+        """
+        Get the policy action from an observation (and optional hidden state).
+        Includes sugar-coating to handle different observations (e.g. normalizing images).
+
+        :param observation: the input observation
+        :param state: The last hidden states (can be None, used in recurrent policies)
+        :param episode_start: The last masks (can be None, used in recurrent policies)
+            this correspond to beginning of episodes,
+            where the hidden states of the RNN must be reset.
+        :param deterministic: Whether or not to return deterministic actions.
+        :return: the model's action and the next hidden state
+            (used in recurrent policies)
+        """

--- a/stable_baselines3/common/type_aliases.py
+++ b/stable_baselines3/common/type_aliases.py
@@ -1,11 +1,13 @@
 """Common aliases for type hints"""
 
 from enum import Enum
+import sys
 from typing import Any, Callable, Dict, List, NamedTuple, Optional, Tuple, Union
 
 import gym
 import numpy as np
 import torch as th
+
 if sys.version_info >= (3, 8):
     from typing import Protocol
 else:

--- a/stable_baselines3/common/type_aliases.py
+++ b/stable_baselines3/common/type_aliases.py
@@ -1,7 +1,7 @@
 """Common aliases for type hints"""
 
-from enum import Enum
 import sys
+from enum import Enum
 from typing import Any, Callable, Dict, List, NamedTuple, Optional, Tuple, Union
 
 import gym

--- a/stable_baselines3/common/type_aliases.py
+++ b/stable_baselines3/common/type_aliases.py
@@ -2,11 +2,11 @@
 
 from enum import Enum
 from typing import Any, Callable, Dict, List, NamedTuple, Optional, Tuple, Union
-from typing_extensions import Protocol
 
 import gym
 import numpy as np
 import torch as th
+from typing_extensions import Protocol
 
 from stable_baselines3.common import callbacks, vec_env
 

--- a/stable_baselines3/dqn/dqn.py
+++ b/stable_baselines3/dqn/dqn.py
@@ -224,7 +224,7 @@ class DQN(OffPolicyAlgorithm):
 
     def predict(
         self,
-        observation: np.ndarray,
+        observation: Union[np.ndarray, Dict[str, np.ndarray]],
         state: Optional[Tuple[np.ndarray, ...]] = None,
         episode_start: Optional[np.ndarray] = None,
         deterministic: bool = False,
@@ -241,7 +241,7 @@ class DQN(OffPolicyAlgorithm):
         """
         if not deterministic and np.random.rand() < self.exploration_rate:
             if is_vectorized_observation(maybe_transpose(observation, self.observation_space), self.observation_space):
-                if isinstance(self.observation_space, gym.spaces.Dict):
+                if isinstance(observation, dict):
                     n_batch = observation[list(observation.keys())[0]].shape[0]
                 else:
                     n_batch = observation.shape[0]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently `evaluate_policy` expects a `model: BaseAlgorithm` i.e. RL algorithm. But it runs fine on any `BasePolicy`, as it just calls `model.predict()` which has an identical type signature between `BaseAlgorithm` and `BasePolicy` -- indeed, `BaseAlgorithm` just forwards it to the policy contained inside it. This PR introduces a `PolicyPredictor` protocol for anything that matches that `predict` type signature, and updates `evaluate_policy`'s type annotation to use that.

I ended up putting `PolicyPredictor` in `type_aliases.py` but I can see an argument for putting it in `policies.py`.

`Protocol` is only available Python >=3.8 so I had to use `typing_extensions` but per discussion in https://github.com/DLR-RM/stable-baselines3/pull/1043#discussion_r961688423 we already have this installed transitively via `pytorch` so this is not a new dependency, although I've added it to `setup.py` to make it explicit

## Motivation and Context
`evaluate_policy` can already be used with policies and this is a fairly common use case. So currently code is failing to type check that works fine at runtime. This PR allows that code to type check.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**)
- [X] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [X] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [X] I have reformatted the code using `make format` (**required**)
- [X] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [X] I have ensured `make pytest` and `make type` both pass. (**required**)
- [X] I have checked that the documentation builds using `make doc` (**required**)

Note: You can run most of the checks using `make commit-checks`.

Note: we are using a maximum length of 127 characters per line

<!--- This Template is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->
