### PR TITLE
Added a next_observations field to RolloutBufferSamples (closes #1328)

### DIFF
--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -17,6 +17,7 @@ New Features:
 ^^^^^^^^^^^^^
 - Added ``repeat_action_probability`` argument in ``AtariWrapper``.
 - Only use ``NoopResetEnv`` and ``MaxAndSkipEnv`` when needed in ``AtariWrapper``
+- Added ``next_observations`` and ``has_next_observation`` fields to ``RolloutBufferSamples`` (@eohomegrownapps)
 
 `SB3-Contrib`_
 ^^^^^^^^^^^^^^
@@ -1227,4 +1228,4 @@ And all the contributors:
 @Gregwar @ycheng517 @quantitative-technologies @bcollazo @git-thor @TibiGG @cool-RR @MWeltevrede
 @Melanol @qgallouedec @francescoluciano @jlp-ue @burakdmb @timothe-chaumont @honglu2875 @yuanmingqi
 @anand-bala @hughperkins @sidney-tio @AlexPasqua @dominicgkerr @Akhilez @Rocamonde @tobirohrer @ZikangXiong
-@DavyMorgan @luizapozzobon @Bonifatius94 @theSquaredError
+@DavyMorgan @luizapozzobon @Bonifatius94 @theSquaredError @eohomegrownapps

--- a/stable_baselines3/common/buffers.py
+++ b/stable_baselines3/common/buffers.py
@@ -459,11 +459,11 @@ class RolloutBuffer(BaseBuffer):
 
             for tensor in _tensor_names:
                 self.__dict__[tensor] = self.swap_and_flatten(self.__dict__[tensor])
-            
+
             is_terminal = np.roll(self.episode_starts, -1, axis=0)
             is_terminal[-1] = np.ones_like(is_terminal[-1])
             self.has_next_observation = 1.0 - self.swap_and_flatten(is_terminal)
-            
+
             self.generator_ready = True
 
         # Return everything, don't create minibatches
@@ -773,11 +773,11 @@ class DictRolloutBuffer(RolloutBuffer):
 
             for tensor in _tensor_names:
                 self.__dict__[tensor] = self.swap_and_flatten(self.__dict__[tensor])
-            
+
             is_terminal = np.roll(self.episode_starts, -1, axis=0)
             is_terminal[-1] = np.ones_like(is_terminal[-1])
             self.has_next_observation = 1.0 - self.swap_and_flatten(is_terminal)
-            
+
             self.generator_ready = True
 
         # Return everything, don't create minibatches
@@ -797,7 +797,9 @@ class DictRolloutBuffer(RolloutBuffer):
         n = self.actions.shape[0]
         return DictRolloutBufferSamples(
             observations={key: self.to_torch(obs[batch_inds]) for (key, obs) in self.observations.items()},
-            next_observations={key: self.to_torch(obs[(batch_inds + self.n_envs) % n]) for (key, obs) in self.observations.items()},
+            next_observations={
+                key: self.to_torch(obs[(batch_inds + self.n_envs) % n]) for (key, obs) in self.observations.items()
+            },
             has_next_observation=self.to_torch(self.has_next_observation[batch_inds].flatten()),
             actions=self.to_torch(self.actions[batch_inds]),
             old_values=self.to_torch(self.values[batch_inds].flatten()),

--- a/stable_baselines3/common/buffers.py
+++ b/stable_baselines3/common/buffers.py
@@ -459,6 +459,11 @@ class RolloutBuffer(BaseBuffer):
 
             for tensor in _tensor_names:
                 self.__dict__[tensor] = self.swap_and_flatten(self.__dict__[tensor])
+            
+            is_terminal = np.roll(self.episode_starts, -1, axis=0)
+            is_terminal[-1] = np.ones_like(is_terminal[-1])
+            self.has_next_observation = 1.0 - self.swap_and_flatten(is_terminal)
+            
             self.generator_ready = True
 
         # Return everything, don't create minibatches
@@ -475,8 +480,11 @@ class RolloutBuffer(BaseBuffer):
         batch_inds: np.ndarray,
         env: Optional[VecNormalize] = None,
     ) -> RolloutBufferSamples:  # type: ignore[signature-mismatch] #FIXME
+        n = self.observations.shape[0]
         data = (
             self.observations[batch_inds],
+            self.observations[(batch_inds + self.n_envs) % n],
+            self.has_next_observation[batch_inds].flatten(),
             self.actions[batch_inds],
             self.values[batch_inds].flatten(),
             self.log_probs[batch_inds].flatten(),
@@ -765,6 +773,11 @@ class DictRolloutBuffer(RolloutBuffer):
 
             for tensor in _tensor_names:
                 self.__dict__[tensor] = self.swap_and_flatten(self.__dict__[tensor])
+            
+            is_terminal = np.roll(self.episode_starts, -1, axis=0)
+            is_terminal[-1] = np.ones_like(is_terminal[-1])
+            self.has_next_observation = 1.0 - self.swap_and_flatten(is_terminal)
+            
             self.generator_ready = True
 
         # Return everything, don't create minibatches
@@ -781,8 +794,11 @@ class DictRolloutBuffer(RolloutBuffer):
         batch_inds: np.ndarray,
         env: Optional[VecNormalize] = None,
     ) -> DictRolloutBufferSamples:  # type: ignore[signature-mismatch] #FIXME
+        n = self.actions.shape[0]
         return DictRolloutBufferSamples(
             observations={key: self.to_torch(obs[batch_inds]) for (key, obs) in self.observations.items()},
+            next_observations={key: self.to_torch(obs[(batch_inds + self.n_envs) % n]) for (key, obs) in self.observations.items()},
+            has_next_observation=self.to_torch(self.has_next_observation[batch_inds].flatten()),
             actions=self.to_torch(self.actions[batch_inds]),
             old_values=self.to_torch(self.values[batch_inds].flatten()),
             old_log_prob=self.to_torch(self.log_probs[batch_inds].flatten()),

--- a/stable_baselines3/common/type_aliases.py
+++ b/stable_baselines3/common/type_aliases.py
@@ -29,6 +29,8 @@ Schedule = Callable[[float], float]
 
 class RolloutBufferSamples(NamedTuple):
     observations: th.Tensor
+    next_observations: th.Tensor
+    has_next_observation: th.Tensor
     actions: th.Tensor
     old_values: th.Tensor
     old_log_prob: th.Tensor
@@ -38,6 +40,8 @@ class RolloutBufferSamples(NamedTuple):
 
 class DictRolloutBufferSamples(NamedTuple):
     observations: TensorDict
+    next_observations: TensorDict
+    has_next_observation: th.Tensor
     actions: th.Tensor
     old_values: th.Tensor
     old_log_prob: th.Tensor

--- a/tests/test_buffers.py
+++ b/tests/test_buffers.py
@@ -6,7 +6,7 @@ from gym import spaces
 
 from stable_baselines3.common.buffers import DictReplayBuffer, DictRolloutBuffer, ReplayBuffer, RolloutBuffer
 from stable_baselines3.common.env_util import make_vec_env
-from stable_baselines3.common.type_aliases import DictReplayBufferSamples, ReplayBufferSamples
+from stable_baselines3.common.type_aliases import DictReplayBufferSamples, DictRolloutBufferSamples, ReplayBufferSamples
 from stable_baselines3.common.utils import get_device
 from stable_baselines3.common.vec_env import VecNormalize
 
@@ -139,3 +139,32 @@ def test_device_buffer(replay_buffer_cls, device):
                 assert value[key].device.type == desired_device
         elif isinstance(value, th.Tensor):
             assert value.device.type == desired_device
+
+
+@pytest.mark.parametrize("rollout_buffer_cls", [RolloutBuffer, DictRolloutBuffer])
+def test_next_observations(rollout_buffer_cls):
+    env = {RolloutBuffer: DummyEnv, DictRolloutBuffer: DummyDictEnv}[rollout_buffer_cls]
+    env = make_vec_env(env)
+
+    buffer = rollout_buffer_cls(100, env.observation_space, env.action_space, device="cpu")
+
+    obs = env.reset()
+    for _ in range(100):
+        action = env.action_space.sample()
+        next_obs, reward, done, info = env.step(action)
+        values, log_prob = th.zeros(1), th.ones(1)
+        if isinstance(obs, dict):
+            buffer.add(obs, action, reward, (obs["observation"] == 1.), values, log_prob)
+        else:
+            buffer.add(obs, action, reward, (obs == 1.), values, log_prob)
+        obs = next_obs
+    
+    data = buffer.get(50)
+    for dp in data:
+        if isinstance(dp, DictRolloutBufferSamples):
+            for k in dp.observations.keys():
+                assert th.equal((dp.observations[k] % 5) + 1, dp.next_observations[k])
+                assert th.equal(th.flatten(dp.observations[k] != 5), dp.has_next_observation)
+        else:
+            assert th.equal((dp.observations % 5) + 1., dp.next_observations)
+            assert th.equal(th.flatten(dp.observations != 5), dp.has_next_observation)

--- a/tests/test_buffers.py
+++ b/tests/test_buffers.py
@@ -154,11 +154,11 @@ def test_next_observations(rollout_buffer_cls):
         next_obs, reward, done, info = env.step(action)
         values, log_prob = th.zeros(1), th.ones(1)
         if isinstance(obs, dict):
-            buffer.add(obs, action, reward, (obs["observation"] == 1.), values, log_prob)
+            buffer.add(obs, action, reward, (obs["observation"] == 1.0), values, log_prob)
         else:
-            buffer.add(obs, action, reward, (obs == 1.), values, log_prob)
+            buffer.add(obs, action, reward, (obs == 1.0), values, log_prob)
         obs = next_obs
-    
+
     data = buffer.get(50)
     for dp in data:
         if isinstance(dp, DictRolloutBufferSamples):
@@ -166,5 +166,5 @@ def test_next_observations(rollout_buffer_cls):
                 assert th.equal((dp.observations[k] % 5) + 1, dp.next_observations[k])
                 assert th.equal(th.flatten(dp.observations[k] != 5), dp.has_next_observation)
         else:
-            assert th.equal((dp.observations % 5) + 1., dp.next_observations)
+            assert th.equal((dp.observations % 5) + 1.0, dp.next_observations)
             assert th.equal(th.flatten(dp.observations != 5), dp.has_next_observation)


### PR DESCRIPTION
## Description
- Added next_observations field and has_next_observation mask to type_aliases.py
- Extended generators in buffers.py to return next_observation and has_next_observation
- Added a test in test_buffers.py

## Motivation and Context
Closes #1328 
- [x] I have raised an issue to propose this change ([required](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) for new features and bug fixes)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist
- [x] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary)
- [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary)
- [x] I have reformatted the code using `make format` (**required**)
- [x] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
    - n.b. there is an error `C901 'BaseAlgorithm.load' is too complex (19)` in a file I did not modify (stable_baselines3/common/base_class.py).
- [ ] I have ensured `make pytest` and `make type` both pass. (**required**)
- [ ] I have checked that the documentation builds using `make doc` (**required**)
(I have been unable to run the last three commands due to Python dependency issues, but the PR delta is very small, so I hope this is fine...)
Note: You can run most of the checks using `make commit-checks`.

Note: we are using a maximum length of 127 characters per line

<!--- This Template is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->
