### PR TITLE
Fix small mistake in docstring

### DIFF
--- a/stable_baselines3/common/monitor.py
+++ b/stable_baselines3/common/monitor.py
@@ -202,7 +202,7 @@ class ResultsWriter:
 
     def write_row(self, epinfo: Dict[str, float]) -> None:
         """
-        Close the file handler
+        Write row of monitor data to csv log file.
 
         :param epinfo: the information on episodic return, length, and time
         """


### PR DESCRIPTION
The docstring for the `write_row` method was copied from the `close` method. This commit updates the summary to match what the method does more closely.

Background: I'm doing a research study on function comments that may be incorrect. You can find more info and a short and optional anonymous survey [here](https://forms.office.com/e/yHv4PRXM2i).
 
Thanks for reviewing!