### PR TITLE
fix Framestack obs env_checker

### DIFF
--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -50,6 +50,7 @@ Bug Fixes:
   for ``Inf`` and ``NaN`` (@lutogniew)
 - Fixed HER ``truncate_last_trajectory()`` (@lbergmann1)
 - Fixed HER desired and achieved goal order in reward computation (@JonathanKuelz)
+- Fixed env_checker for FrameStack observation (@corentinlger)
 
 Deprecations:
 ^^^^^^^^^^^^^
@@ -1361,4 +1362,4 @@ And all the contributors:
 @Melanol @qgallouedec @francescoluciano @jlp-ue @burakdmb @timothe-chaumont @honglu2875
 @anand-bala @hughperkins @sidney-tio @AlexPasqua @dominicgkerr @Akhilez @Rocamonde @tobirohrer @ZikangXiong
 @DavyMorgan @luizapozzobon @Bonifatius94 @theSquaredError @harveybellini @DavyMorgan @FieteO @jonasreiher @npit @WeberSamuel @troiganto
-@lutogniew @lbergmann1
+@lutogniew @lbergmann1 @corentinlger

--- a/stable_baselines3/common/env_checker.py
+++ b/stable_baselines3/common/env_checker.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Union
 import gymnasium as gym
 import numpy as np
 from gymnasium import spaces
+from gymnasium.wrappers.frame_stack import LazyFrames
 
 from stable_baselines3.common.preprocessing import check_for_nested_spaces, is_image_space_channels_first
 from stable_baselines3.common.vec_env import DummyVecEnv, VecCheckNan
@@ -171,7 +172,9 @@ def _check_goal_env_compute_reward(
     assert rewards[0] == reward, f"Vectorized computation of reward differs from single computation: {rewards[0]} != {reward}"
 
 
-def _check_obs(obs: Union[tuple, dict, np.ndarray, int], observation_space: spaces.Space, method_name: str) -> None:
+def _check_obs(
+    obs: Union[tuple, dict, np.ndarray, int, LazyFrames], observation_space: spaces.Space, method_name: str
+) -> None:
     """
     Check that the observation returned by the environment
     correspond to the declared one.
@@ -187,7 +190,10 @@ def _check_obs(obs: Union[tuple, dict, np.ndarray, int], observation_space: spac
         # `sample()` will return a np.int64 instead of an int
         assert np.issubdtype(type(obs), np.integer), f"The observation returned by `{method_name}()` method must be an int"
     elif _is_numpy_array_space(observation_space):
-        assert isinstance(obs, np.ndarray), f"The observation returned by `{method_name}()` method must be a numpy array"
+        # Check if obs is a ndarray or a FrameStacking of ndarrays
+        assert isinstance(
+            obs, (np.ndarray, LazyFrames)
+        ), f"The observation returned by `{method_name}()` method must be a numpy array"
 
     # Additional checks for numpy arrays, so the error message is clearer (see GH#1399)
     if isinstance(obs, np.ndarray):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --> 
Fix env_checker function for gymnasium FrameStacked observations (previously raised an error)

## Description
<!--- Describe your changes in detail -->
FrameStacked obs from Gymnasium only support Box obs and are stored in a LazyFrames class. Because the associated obs_space is a np.ndarray, I only added a condition where I still check if the obs is a np.ndarray class, but also a LazyFrames class (when _is_numpy_array_space is True).

@qgallouedec  also proposed to use np.can_cast which worked, but the type hinting for the function became really long (and could lead to errors) because you can also cast str, bytes ... So I don't know if the solution used here is the best but it seems to work. What do you think about it ? 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? --> 
Solves the problem mentionned in [this issue](https://github.com/DLR-RM/stable-baselines3/issues/1500).
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->
closes #1500 
- [x ] I have raised an issue to propose this change ([required](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) for new features and bug fixes)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**)
- [x ] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [ x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ x] I have updated the documentation accordingly.
- [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary)
- [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary)
- [x ] I have reformatted the code using `make format` (**required**)
- [ x] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [ ] I have ensured `make pytest` and `make type` both pass. (**required**) --> I don't have a GPU and had a segmentation error by running 'make pytest' 
- [ x] I have checked that the documentation builds using `make doc` (**required**)

Note: You can run most of the checks using `make commit-checks`.

Note: we are using a maximum length of 127 characters per line

<!--- This Template is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->
