### PR TITLE
BitFlippingEnv argument check and docs clarification

### DIFF
--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -26,6 +26,7 @@ Bug Fixes:
 - Fixed ``render_mode`` which was not properly loaded when using ``VecNormalize.load()``
 - Fixed success reward dtype in ``SimpleMultiObsEnv`` (@NixGD)
 - Fixed check_env for Sequence observation space (@corentinlger)
+- Prevents instantiating BitFlippingEnv with conflicting observation spaces (@kylesayrs)
 
 `SB3-Contrib`_
 ^^^^^^^^^^^^^^

--- a/stable_baselines3/common/envs/bit_flipping_env.py
+++ b/stable_baselines3/common/envs/bit_flipping_env.py
@@ -44,9 +44,13 @@ class BitFlippingEnv(Env):
         self.image_shape = (1, 36, 36) if channel_first else (36, 36, 1)
         # The achieved goal is determined by the current state
         # here, it is a special where they are equal
+
+        # observation space for observations given to the model 
         self.observation_space = self._make_observation_space(
             discrete_obs_space, image_obs_space, n_bits
         )
+        # observation space used to update internal state
+        self._obs_space = spaces.MultiBinary(n_bits)
 
         if continuous:
             self.action_space = spaces.Box(-1, 1, shape=(n_bits,), dtype=np.float32)
@@ -62,7 +66,7 @@ class BitFlippingEnv(Env):
         self.current_step = 0
 
     def seed(self, seed: int) -> None:
-        self.observation_space.seed(seed)
+        self._obs_space.seed(seed)
 
     def convert_if_needed(self, state: np.ndarray) -> Union[int, np.ndarray]:
         """
@@ -182,9 +186,9 @@ class BitFlippingEnv(Env):
         self, *, seed: Optional[int] = None, options: Optional[Dict] = None
     ) -> Tuple[Dict[str, Union[int, np.ndarray]], Dict]:
         if seed is not None:
-            self.observation_space.seed(seed)
+            self._obs_space.seed(seed)
         self.current_step = 0
-        self.state = self.observation_space.sample()
+        self.state = self._obs_space.sample()
         return self._get_obs(), {}
 
     def step(self, action: Union[np.ndarray, int]) -> GymStepReturn:

--- a/stable_baselines3/common/envs/bit_flipping_env.py
+++ b/stable_baselines3/common/envs/bit_flipping_env.py
@@ -44,52 +44,9 @@ class BitFlippingEnv(Env):
         self.image_shape = (1, 36, 36) if channel_first else (36, 36, 1)
         # The achieved goal is determined by the current state
         # here, it is a special where they are equal
-        if discrete_obs_space:
-            # In the discrete case, the agent act on the binary
-            # representation of the observation
-            self.observation_space = spaces.Dict(
-                {
-                    "observation": spaces.Discrete(2**n_bits),
-                    "achieved_goal": spaces.Discrete(2**n_bits),
-                    "desired_goal": spaces.Discrete(2**n_bits),
-                }
-            )
-        elif image_obs_space:
-            # When using image as input,
-            # one image contains the bits 0 -> 0, 1 -> 255
-            # and the rest is filled with zeros
-            self.observation_space = spaces.Dict(
-                {
-                    "observation": spaces.Box(
-                        low=0,
-                        high=255,
-                        shape=self.image_shape,
-                        dtype=np.uint8,
-                    ),
-                    "achieved_goal": spaces.Box(
-                        low=0,
-                        high=255,
-                        shape=self.image_shape,
-                        dtype=np.uint8,
-                    ),
-                    "desired_goal": spaces.Box(
-                        low=0,
-                        high=255,
-                        shape=self.image_shape,
-                        dtype=np.uint8,
-                    ),
-                }
-            )
-        else:
-            self.observation_space = spaces.Dict(
-                {
-                    "observation": spaces.MultiBinary(n_bits),
-                    "achieved_goal": spaces.MultiBinary(n_bits),
-                    "desired_goal": spaces.MultiBinary(n_bits),
-                }
-            )
-
-        self.obs_space = spaces.MultiBinary(n_bits)
+        self.observation_space = self._make_observation_space(
+            discrete_obs_space, image_obs_space, n_bits
+        )
 
         if continuous:
             self.action_space = spaces.Box(-1, 1, shape=(n_bits,), dtype=np.float32)
@@ -105,7 +62,7 @@ class BitFlippingEnv(Env):
         self.current_step = 0
 
     def seed(self, seed: int) -> None:
-        self.obs_space.seed(seed)
+        self.observation_space.seed(seed)
 
     def convert_if_needed(self, state: np.ndarray) -> Union[int, np.ndarray]:
         """
@@ -143,6 +100,69 @@ class BitFlippingEnv(Env):
         else:
             bit_vector = np.array(state).reshape(batch_size, -1)
         return bit_vector
+    
+    def _make_observation_space(
+        self,
+        discrete_obs_space: bool,    
+        image_obs_space: bool,
+        n_bits: int
+    ) -> spaces.Space:
+        """
+        Helper to create observation space
+
+        :param discrete_obs_space: Whether to use the discrete observation version
+        :param image_obs_space: Whether to use the image observation version
+        :param n_bits: The number of bits used to represent the state
+        :return: the environment observation space
+        """
+        if discrete_obs_space and image_obs_space:
+            raise ValueError("Cannot use both discrete and image observation spaces")
+
+        if discrete_obs_space:
+            # In the discrete case, the agent act on the binary
+            # representation of the observation
+            return spaces.Dict(
+                {
+                    "observation": spaces.Discrete(2**n_bits),
+                    "achieved_goal": spaces.Discrete(2**n_bits),
+                    "desired_goal": spaces.Discrete(2**n_bits),
+                }
+            )
+        
+        if image_obs_space:
+            # When using image as input,
+            # one image contains the bits 0 -> 0, 1 -> 255
+            # and the rest is filled with zeros
+            return spaces.Dict(
+                {
+                    "observation": spaces.Box(
+                        low=0,
+                        high=255,
+                        shape=self.image_shape,
+                        dtype=np.uint8,
+                    ),
+                    "achieved_goal": spaces.Box(
+                        low=0,
+                        high=255,
+                        shape=self.image_shape,
+                        dtype=np.uint8,
+                    ),
+                    "desired_goal": spaces.Box(
+                        low=0,
+                        high=255,
+                        shape=self.image_shape,
+                        dtype=np.uint8,
+                    ),
+                }
+            )
+        
+        return spaces.Dict(
+            {
+                "observation": spaces.MultiBinary(n_bits),
+                "achieved_goal": spaces.MultiBinary(n_bits),
+                "desired_goal": spaces.MultiBinary(n_bits),
+            }
+        )
 
     def _get_obs(self) -> Dict[str, Union[int, np.ndarray]]:
         """
@@ -162,9 +182,9 @@ class BitFlippingEnv(Env):
         self, *, seed: Optional[int] = None, options: Optional[Dict] = None
     ) -> Tuple[Dict[str, Union[int, np.ndarray]], Dict]:
         if seed is not None:
-            self.obs_space.seed(seed)
+            self.observation_space.seed(seed)
         self.current_step = 0
-        self.state = self.obs_space.sample()
+        self.state = self.observation_space.sample()
         return self._get_obs(), {}
 
     def step(self, action: Union[np.ndarray, int]) -> GymStepReturn:

--- a/stable_baselines3/common/envs/bit_flipping_env.py
+++ b/stable_baselines3/common/envs/bit_flipping_env.py
@@ -13,15 +13,17 @@ class BitFlippingEnv(Env):
     Simple bit flipping env, useful to test HER.
     The goal is to flip all the bits to get a vector of ones.
     In the continuous variant, if the ith action component has a value > 0,
-    then the ith bit will be flipped.
+    then the ith bit will be flipped. Uses a ``MultiBinary`` observation space
+    by default.
 
     :param n_bits: Number of bits to flip
     :param continuous: Whether to use the continuous actions version or not,
         by default, it uses the discrete one
     :param max_steps: Max number of steps, by default, equal to n_bits
     :param discrete_obs_space: Whether to use the discrete observation
-        version or not, by default, it uses the ``MultiBinary`` one
-    :param image_obs_space: Use image as input instead of the ``MultiBinary`` one.
+        version or not, ie a one-hot encoding of all possible states
+    :param image_obs_space: Whether to use an image observation version
+        or not, ie a greyscale image of the state
     :param channel_first: Whether to use channel-first or last image.
     """
 

--- a/stable_baselines3/common/envs/bit_flipping_env.py
+++ b/stable_baselines3/common/envs/bit_flipping_env.py
@@ -45,10 +45,8 @@ class BitFlippingEnv(Env):
         # The achieved goal is determined by the current state
         # here, it is a special where they are equal
 
-        # observation space for observations given to the model 
-        self.observation_space = self._make_observation_space(
-            discrete_obs_space, image_obs_space, n_bits
-        )
+        # observation space for observations given to the model
+        self.observation_space = self._make_observation_space(discrete_obs_space, image_obs_space, n_bits)
         # observation space used to update internal state
         self._obs_space = spaces.MultiBinary(n_bits)
 
@@ -104,13 +102,8 @@ class BitFlippingEnv(Env):
         else:
             bit_vector = np.array(state).reshape(batch_size, -1)
         return bit_vector
-    
-    def _make_observation_space(
-        self,
-        discrete_obs_space: bool,    
-        image_obs_space: bool,
-        n_bits: int
-    ) -> spaces.Space:
+
+    def _make_observation_space(self, discrete_obs_space: bool, image_obs_space: bool, n_bits: int) -> spaces.Dict:
         """
         Helper to create observation space
 
@@ -132,7 +125,7 @@ class BitFlippingEnv(Env):
                     "desired_goal": spaces.Discrete(2**n_bits),
                 }
             )
-        
+
         if image_obs_space:
             # When using image as input,
             # one image contains the bits 0 -> 0, 1 -> 255
@@ -159,7 +152,7 @@ class BitFlippingEnv(Env):
                     ),
                 }
             )
-        
+
         return spaces.Dict(
             {
                 "observation": spaces.MultiBinary(n_bits),


### PR DESCRIPTION
## Description
1. Create a helper function `_make_observation_space` which handles creating the observation space and checking that `discrete_obs_space` and `image_obs_space` do not conflict
2. Rename `self.obs_space` to `self._obs_space` to clarify it is for managing the internal state only. Added a comment explaining this
3. Better explain what each of the observation spaces mean in the documentation

## Motivation and Context
These changes make it clearer to users how the internal `obs_space` member is being used as well as what each of the observation space variants mean.
closes #1691
- [x] I have raised an issue to propose this change ([required](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) for new features and bug fixes)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (update in the documentation)

## Checklist
- [x] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the changelog accordingly (**required**).
- [x] My change requires a change to the documentation. (note: requires is a strong word here)
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
- [x] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (unnecessary)
- [x] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (unnecessary)
- [x] I have reformatted the code using `make format` (**required**)
- [x] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [x] I have ensured `make pytest` and `make type` both pass. (**required**)
- [x] I have checked that the documentation builds using `make doc` (**required**)

Note: You can run most of the checks using `make commit-checks`.
Note: we are using a maximum length of 127 characters per line

- [x] I have checked the example in the documentation works as expected (modules/her.rst) 

Given that the changes are minor, I do not think it warrants a dedicated unit test (correct me if I'm wrong). You can verify the environment is constructed, trains, and evaluates correctly using the below script.
```
from stable_baselines3 import HerReplayBuffer, DDPG, DQN, SAC, TD3
from stable_baselines3.her.goal_selection_strategy import GoalSelectionStrategy
from stable_baselines3.common.envs import BitFlippingEnv


def test(model_class, discrete_obs_space, image_obs_space):
    model_class = DDPG  # works also with SAC, DDPG and TD3
    N_BITS = 15

    env = BitFlippingEnv(
        n_bits=N_BITS,
        continuous=model_class in [DDPG, SAC, TD3],
        discrete_obs_space=discrete_obs_space,
        image_obs_space=image_obs_space,
        max_steps=N_BITS
    )

    # Available strategies (cf paper): future, final, episode
    goal_selection_strategy = "future" # equivalent to GoalSelectionStrategy.FUTURE

    # Initialize the model
    model = model_class(
        "MultiInputPolicy",
        env,
        replay_buffer_class=HerReplayBuffer,
        # Parameters for HER
        replay_buffer_kwargs=dict(
            n_sampled_goal=4,
            goal_selection_strategy=goal_selection_strategy,
        ),
        verbose=1,
    )

    # Train the model
    model.learn(10)

    model.save("./her_bit_env")
    # Because it needs access to `env.compute_reward()`
    # HER must be loaded with the env
    model = model_class.load("./her_bit_env", env=env)

    obs, info = env.reset()
    for _ in range(10):
        action, _ = model.predict(obs, deterministic=True)
        obs, reward, terminated, truncated, _ = env.step(action)
        if terminated or truncated:
            obs, info = env.reset()


if __name__ == "__main__":
    for discrete_obs_space in [True, False]:
        for image_obs_space in [True, False]:
            for model_class in [DQN, DDPG, SAC, TD3]:
                try:
                    test(model_class, discrete_obs_space, image_obs_space)
                except ValueError as exception:
                    if (discrete_obs_space and image_obs_space):
                        continue
                    else:
                        print("Failed to raise error")
                        exit(1)

    print("Success")
```

<!--- This Template is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->
