### PR TITLE
Create optimizer in `OnPolicyAlgorithm` only after the device is set

### DIFF
--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -3,6 +3,13 @@
 Changelog
 ==========
 
+Unreleased
+----------
+
+Bug Fixes:
+^^^^^^^^^^
+- In ``OnPolicyAlgorithm``, delay the initialization of the optimizer until after the correct compute-device type is set (@cmangla)
+
 Release 2.2.1 (2023-11-17)
 --------------------------
 **Support for options at reset, bug fixes and better error messages**

--- a/stable_baselines3/common/on_policy_algorithm.py
+++ b/stable_baselines3/common/on_policy_algorithm.py
@@ -131,9 +131,15 @@ class OnPolicyAlgorithm(BaseAlgorithm):
             **self.rollout_buffer_kwargs,
         )
         self.policy = self.policy_class(  # type: ignore[assignment]
-            self.observation_space, self.action_space, self.lr_schedule, use_sde=self.use_sde, **self.policy_kwargs
+            self.observation_space,
+            self.action_space,
+            self.lr_schedule,
+            use_sde=self.use_sde,
+            _init_optimizer=False,
+            **self.policy_kwargs,
         )
         self.policy = self.policy.to(self.device)
+        self.policy._build_optimizer(self.lr_schedule)
 
     def collect_rollouts(
         self,


### PR DESCRIPTION
Attempt to fix #1770 in a fully backward compatible manner.

## Description
In PPO, the optimizer in the policy is created before the computation-device for the class is correctly set. This is a problem when the optimizer checks the target computation-device on initialization. This is a backward compatible fix.

## Motivation and Context
Fixes #1770 . One can now use the `fused` option in the Adam optimizer on CUDA devices, which, according to the documentation, is faster.
- [x] I have raised an issue to propose this change

## Types of changes
- [x] Bug fix

## Checklist
- [x] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the changelog accordingly (**required**).
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
- [x] I have reformatted the code using `make format` (**required**)
- [x] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [x] I have ensured `make pytest` and `make type` both pass. (**required**)
- [x] I have checked that the documentation builds using `make doc` (**required**)

