### PR TITLE
start value of Discrete spaces

### DIFF
--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -18,6 +18,7 @@ New Features:
 
 Bug Fixes:
 ^^^^^^^^^^
+- support for start-value in spaces.Discrete
 
 `SB3-Contrib`_
 ^^^^^^^^^^^^^^

--- a/stable_baselines3/common/on_policy_algorithm.py
+++ b/stable_baselines3/common/on_policy_algorithm.py
@@ -214,7 +214,10 @@ class OnPolicyAlgorithm(BaseAlgorithm):
                     # Otherwise, clip the actions to avoid out of bound error
                     # as we are sampling from an unbounded Gaussian distribution
                     clipped_actions = np.clip(actions, self.action_space.low, self.action_space.high)
-
+            elif isinstance(self.action_space, spaces.Discrete):
+                # match discrete actions bounds
+                clipped_actions = np.add(clipped_actions, self.action_space.start)
+                
             new_obs, rewards, dones, infos = env.step(clipped_actions)
 
             self.num_timesteps += env.num_envs

--- a/stable_baselines3/common/policies.py
+++ b/stable_baselines3/common/policies.py
@@ -377,7 +377,10 @@ class BasePolicy(BaseModel, ABC):
                 # Actions could be on arbitrary scale, so clip the actions to avoid
                 # out of bound error (e.g. if sampling from a Gaussian distribution)
                 actions = np.clip(actions, self.action_space.low, self.action_space.high)  # type: ignore[assignment, arg-type]
-
+        elif isinstance(self.action_space, spaces.Discrete):
+                # Rescale in case of discrete action
+                actions = np.add(actions, self.action_space.start)
+            
         # Remove batch dimension if needed
         if not vectorized_env:
             assert isinstance(actions, np.ndarray)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This fixes the missing applying of start value of Discrete Space

The start value of "spaces.Discrete(3, start=-1)" has no effect and does not shift the space to given start value, even tough there are examples in the Discrete class like: observation_space = Discrete(3, start=-1, seed=42)  # {-1, 0, 1}
All Discrete Spaces start currently at zero.

## Motivation and Context
This is a bug-fix relating to https://github.com/DLR-RM/stable-baselines3/issues/2052, https://github.com/DLR-RM/stable-baselines3/issues/913, https://github.com/DLR-RM/stable-baselines3/issues/1295, https://github.com/DLR-RM/stable-baselines3/issues/1378
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->
- [x] I have raised an issue to propose this change ([required](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) for new features and bug fixes)

## Types of changes
**The start value of spaces.Discrete is added to the actions to properly shift space**
Reason for this position is, its the same position, the final scaling of spaces.Box happen. spaces.Discrete was never handled
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary)
- [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary)
- [ ] I have reformatted the code using `make format` (**required**)
- [ ] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [ ] I have ensured `make pytest` and `make type` both pass. (**required**)
- [ ] I have checked that the documentation builds using `make doc` (**required**)

Note: You can run most of the checks using `make commit-checks`.

Note: we are using a maximum length of 127 characters per line

<!--- This Template is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->