### PR TITLE
start value of Discrete spaces

### DIFF
--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -1740,4 +1740,4 @@ And all the contributors:
 @DavyMorgan @luizapozzobon @Bonifatius94 @theSquaredError @harveybellini @DavyMorgan @FieteO @jonasreiher @npit @WeberSamuel @troiganto
 @lutogniew @lbergmann1 @lukashass @BertrandDecoster @pseudo-rnd-thoughts @stefanbschneider @kyle-he @PatrickHelm @corentinlger
 @marekm4 @stagoverflow @rushitnshah @markscsmith @NickLucche @cschindlbeck @peteole @jak3122 @will-maclean
-@brn-dev @jmacglashan @kplers
+@brn-dev @jmacglashan @kplers @JoshuaBluem

--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -18,6 +18,7 @@ New Features:
 
 Bug Fixes:
 ^^^^^^^^^^
+- Support for start value in discrete action spaces
 
 `SB3-Contrib`_
 ^^^^^^^^^^^^^^

--- a/stable_baselines3/common/env_checker.py
+++ b/stable_baselines3/common/env_checker.py
@@ -16,6 +16,7 @@ def _is_numpy_array_space(space: spaces.Space) -> bool:
     """
     return not isinstance(space, (spaces.Dict, spaces.Tuple))
 
+
 def _check_image_input(observation_space: spaces.Box, key: str = "") -> None:
     """
     Check that the input will be compatible with Stable-Baselines
@@ -59,7 +60,7 @@ def _check_unsupported_spaces(env: gym.Env, observation_space: spaces.Space, act
 
     if isinstance(observation_space, spaces.Dict):
         nested_dict = False
-        for key, space in observation_space.spaces.items():
+        for _key, space in observation_space.spaces.items():
             if isinstance(space, spaces.Dict):
                 nested_dict = True
 

--- a/stable_baselines3/common/env_checker.py
+++ b/stable_baselines3/common/env_checker.py
@@ -16,31 +16,6 @@ def _is_numpy_array_space(space: spaces.Space) -> bool:
     """
     return not isinstance(space, (spaces.Dict, spaces.Tuple))
 
-
-def _starts_at_zero(space: Union[spaces.Discrete, spaces.MultiDiscrete]) -> bool:
-    """
-    Return False if a (Multi)Discrete space has a non-zero start.
-    """
-    return np.allclose(space.start, np.zeros_like(space.start))
-
-
-def _check_non_zero_start(space: spaces.Space, space_type: str = "observation", key: str = "") -> None:
-    """
-    :param space: Observation or action space
-    :param space_type: information about whether it is an observation or action space
-        (for the warning message)
-    :param key: When the observation space comes from a Dict space, we pass the
-        corresponding key to have more precise warning messages. Defaults to "".
-    """
-    if isinstance(space, (spaces.Discrete, spaces.MultiDiscrete)) and not _starts_at_zero(space):
-        maybe_key = f"(key='{key}')" if key else ""
-        warnings.warn(
-            f"{type(space).__name__} {space_type} space {maybe_key} with a non-zero start (start={space.start}) "
-            "is not supported by Stable-Baselines3. "
-            f"You can use a wrapper or update your {space_type} space."
-        )
-
-
 def _check_image_input(observation_space: spaces.Box, key: str = "") -> None:
     """
     Check that the input will be compatible with Stable-Baselines
@@ -87,7 +62,6 @@ def _check_unsupported_spaces(env: gym.Env, observation_space: spaces.Space, act
         for key, space in observation_space.spaces.items():
             if isinstance(space, spaces.Dict):
                 nested_dict = True
-            _check_non_zero_start(space, "observation", key)
 
         if nested_dict:
             warnings.warn(
@@ -115,16 +89,12 @@ def _check_unsupported_spaces(env: gym.Env, observation_space: spaces.Space, act
             "which is supported by SB3."
         )
 
-    _check_non_zero_start(observation_space, "observation")
-
     if isinstance(observation_space, spaces.Sequence):
         warnings.warn(
             "Sequence observation space is not supported by Stable-Baselines3. "
             "You can pad your observation to have a fixed size instead.\n"
             "Note: The checks for returned values are skipped."
         )
-
-    _check_non_zero_start(action_space, "action")
 
     if not _is_numpy_array_space(action_space):
         warnings.warn(

--- a/stable_baselines3/common/off_policy_algorithm.py
+++ b/stable_baselines3/common/off_policy_algorithm.py
@@ -401,7 +401,7 @@ class OffPolicyAlgorithm(BaseAlgorithm):
             # We store the scaled action in the buffer
             buffer_action = scaled_action
             action = self.policy.unscale_action(scaled_action)
-        elif isinstance(self.action_space, spaces.Discrete):
+        elif isinstance(self.action_space, (spaces.Discrete, spaces.MultiDiscrete)):
             # Discrete case: Shift action values so every action starts from zero
             scaled_action = self.policy.scale_action(unscaled_action)
 

--- a/stable_baselines3/common/on_policy_algorithm.py
+++ b/stable_baselines3/common/on_policy_algorithm.py
@@ -213,7 +213,7 @@ class OnPolicyAlgorithm(BaseAlgorithm):
                     # Otherwise, clip the actions to avoid out of bound error
                     # as we are sampling from an unbounded Gaussian distribution
                     unscaled_actions = np.clip(actions, self.action_space.low, self.action_space.high)
-            elif isinstance(self.action_space, spaces.Discrete):
+            elif isinstance(self.action_space, (spaces.Discrete, spaces.MultiDiscrete)):
                 # Scale actions to match action-space bounds
                 unscaled_actions = self.policy.unscale_action(unscaled_actions)  # type: ignore[assignment, arg-type]
 

--- a/stable_baselines3/common/policies.py
+++ b/stable_baselines3/common/policies.py
@@ -377,7 +377,7 @@ class BasePolicy(BaseModel, ABC):
                 # Actions could be on arbitrary scale, so clip the actions to avoid
                 # out of bound error (e.g. if sampling from a Gaussian distribution)
                 actions = np.clip(actions, self.action_space.low, self.action_space.high)  # type: ignore[assignment, arg-type]
-        elif isinstance(self.action_space, spaces.Discrete):
+        elif isinstance(self.action_space, (spaces.Discrete, spaces.MultiDiscrete)):
             # transform action to its action-space bounds starting from its defined start value
             actions = self.unscale_action(actions)  # type: ignore[assignment, arg-type]
 
@@ -406,7 +406,7 @@ class BasePolicy(BaseModel, ABC):
             # Box case
             low, high = self.action_space.low, self.action_space.high
             scaled_action = 2.0 * ((action - low) / (high - low)) - 1.0
-        elif isinstance(self.action_space, spaces.Discrete):
+        elif isinstance(self.action_space, (spaces.Discrete, spaces.MultiDiscrete)):
             # discrete actions case
             scaled_action = np.subtract(action, self.action_space.start)
         else:
@@ -429,7 +429,7 @@ class BasePolicy(BaseModel, ABC):
         if isinstance(self.action_space, spaces.Box):
             low, high = self.action_space.low, self.action_space.high
             unscaled_action = low + (0.5 * (scaled_action + 1.0) * (high - low))
-        elif isinstance(self.action_space, spaces.Discrete):
+        elif isinstance(self.action_space, (spaces.Discrete, spaces.MultiDiscrete)):
             # match discrete actions bounds
             unscaled_action = np.add(scaled_action, self.action_space.start)
         else:

--- a/stable_baselines3/common/policies.py
+++ b/stable_baselines3/common/policies.py
@@ -410,7 +410,7 @@ class BasePolicy(BaseModel, ABC):
             # discrete actions case
             scaled_action = np.subtract(action, self.action_space.start)
         else:
-            raise AssertionError(f"Trying to scale an action using an action space that is not a Box() or Discrete(): {self.action_space}")
+            raise NotImplementedError(f"Trying to scale an action using action space: {self.action_space}")
 
         return scaled_action
 
@@ -433,7 +433,7 @@ class BasePolicy(BaseModel, ABC):
             # match discrete actions bounds
             unscaled_action = np.add(scaled_action, self.action_space.start)
         else:
-            raise AssertionError(f"Trying to unscale an action using an action space that is not a Box() or Discrete(): {self.action_space}")
+            raise NotImplementedError(f"Trying to unscale an action using action space: {self.action_space}")
 
         return unscaled_action
 

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -121,14 +121,8 @@ def test_high_dimension_action_space():
         spaces.Dict({"position": spaces.Dict({"abs": spaces.Discrete(5), "rel": spaces.Discrete(2)})}),
         # Small image inside a dict
         spaces.Dict({"img": spaces.Box(low=0, high=255, shape=(32, 32, 3), dtype=np.uint8)}),
-        # Non zero start index
-        spaces.Discrete(3, start=-1),
         # 2D MultiDiscrete
         spaces.MultiDiscrete(np.array([[4, 4], [2, 3]])),
-        # Non zero start index (MultiDiscrete)
-        spaces.MultiDiscrete([4, 4], start=[1, 0]),
-        # Non zero start index inside a Dict
-        spaces.Dict({"obs": spaces.Discrete(3, start=1)}),
     ],
 )
 def test_non_default_spaces(new_obs_space):
@@ -166,10 +160,6 @@ def test_non_default_spaces(new_obs_space):
         spaces.Box(low=-np.inf, high=1, shape=(2,), dtype=np.float32),
         # Almost good, except for one dim
         spaces.Box(low=np.array([-1, -1, -1]), high=np.array([1, 1, 0.99]), dtype=np.float32),
-        # Non zero start index
-        spaces.Discrete(3, start=-1),
-        # Non zero start index (MultiDiscrete)
-        spaces.MultiDiscrete([4, 4], start=[1, 0]),
     ],
 )
 def test_non_default_action_spaces(new_action_space):

--- a/tests/test_spaces.py
+++ b/tests/test_spaces.py
@@ -53,24 +53,30 @@ class DummyMultiDiscreteSpace(DummyEnv):
             BOX_SPACE_FLOAT32,
         )
 
+
 class ActionBoundsTestClass(DummyEnv):
     def step(self, action):
         if isinstance(self.action_space, spaces.Discrete):
-            assert np.all(action >= self.action_space.start), (
-                f"Discrete action {action} is below the lower bound {self.action_space.start}")
-            assert np.all(action <= self.action_space.start + self.action_space.n), (
-                f"Discrete action {action} is above the upper bound {self.action_space.start}+{self.action_space.n}")
+            assert np.all(
+                action >= self.action_space.start
+            ), f"Discrete action {action} is below the lower bound {self.action_space.start}"
+            assert np.all(
+                action <= self.action_space.start + self.action_space.n
+            ), f"Discrete action {action} is above the upper bound {self.action_space.start}+{self.action_space.n}"
         elif isinstance(self.action_space, spaces.MultiDiscrete):
-            assert np.all(action >= self.action_space.start), (
-                f"MultiDiscrete action {action} is below the lower bound {self.action_space.start}")
-            assert np.all(action <= self.action_space.start + self.action_space.nvec), (
-                f"MultiDiscrete action {action} is above the upper bound {self.action_space.start}+{self.action_space.nvec}")
+            assert np.all(
+                action >= self.action_space.start
+            ), f"MultiDiscrete action {action} is below the lower bound {self.action_space.start}"
+            assert np.all(
+                action <= self.action_space.start + self.action_space.nvec
+            ), f"MultiDiscrete action {action} is above the upper bound {self.action_space.start}+{self.action_space.nvec}"
         elif isinstance(self.action_space, spaces.Box):
-            assert np.all(action >= self.action_space.low), (
-                f"Action {action} is below the lower bound {self.action_space.low}")
-            assert np.all(action <= self.action_space.high), (
-                f"Action {action} is above the upper bound {self.action_space.high}")
+            assert np.all(action >= self.action_space.low), f"Action {action} is below the lower bound {self.action_space.low}"
+            assert np.all(
+                action <= self.action_space.high
+            ), f"Action {action} is above the upper bound {self.action_space.high}"
         return self.observation_space.sample(), 0.0, False, False, {}
+
 
 @pytest.mark.parametrize(
     "env",
@@ -189,17 +195,17 @@ def test_float64_action_space(model_class, obs_space, action_space):
 
 
 @pytest.mark.parametrize(
-        "model_class, action_space",
-        [
-            # on-policy test
-            (PPO, spaces.Discrete(5, start=-6543)),
-            (PPO, spaces.MultiDiscrete([4, 3], start=[-6543, 11])),
-            (PPO, spaces.Box(low=2344, high=2345, shape=(3,), dtype=np.float32)),
-            # off-policy test
-            (DQN, spaces.Discrete(2, start=9923)),
-            (SAC, spaces.Box(low=-123, high=-122, shape=(1,), dtype=np.float32)),
-        ],
-    )
+    "model_class, action_space",
+    [
+        # on-policy test
+        (PPO, spaces.Discrete(5, start=-6543)),
+        (PPO, spaces.MultiDiscrete([4, 3], start=[-6543, 11])),
+        (PPO, spaces.Box(low=2344, high=2345, shape=(3,), dtype=np.float32)),
+        # off-policy test
+        (DQN, spaces.Discrete(2, start=9923)),
+        (SAC, spaces.Box(low=-123, high=-122, shape=(1,), dtype=np.float32)),
+    ],
+)
 def test_space_bounds(model_class, action_space):
     obs_space = BOX_SPACE_FLOAT32
     env = ActionBoundsTestClass(obs_space, action_space)
@@ -220,20 +226,20 @@ def test_space_bounds(model_class, action_space):
 
     action, _ = model.predict(initial_obs, deterministic=False)
     if isinstance(action_space, spaces.Discrete):
-        assert np.all(action >= action_space.start), (
-            f"Discrete action {action} is below the lower bound {action_space.start}")
-        assert np.all(action <= action_space.start + action_space.n), (
-            f"Discrete action {action} is above the upper bound {action_space.start}+{action_space.n}")
+        assert np.all(action >= action_space.start), f"Discrete action {action} is below the lower bound {action_space.start}"
+        assert np.all(
+            action <= action_space.start + action_space.n
+        ), f"Discrete action {action} is above the upper bound {action_space.start}+{action_space.n}"
     elif isinstance(action_space, spaces.MultiDiscrete):
-        assert np.all(action >= action_space.start), (
-            f"MultiDiscrete action {action} is below the lower bound {action_space.start}")
-        assert np.all(action <= action_space.start + action_space.nvec), (
-            f"MultiDiscrete action {action} is above the upper bound {action_space.start}+{action_space.nvec}")
+        assert np.all(
+            action >= action_space.start
+        ), f"MultiDiscrete action {action} is below the lower bound {action_space.start}"
+        assert np.all(
+            action <= action_space.start + action_space.nvec
+        ), f"MultiDiscrete action {action} is above the upper bound {action_space.start}+{action_space.nvec}"
     elif isinstance(action_space, spaces.Box):
-        assert np.all(action >= action_space.low), (
-            f"Action {action} is below the lower bound {action_space.low}")
-        assert np.all(action <= action_space.high), (
-            f"Action {action} is above the upper bound {action_space.high}")
+        assert np.all(action >= action_space.low), f"Action {action} is below the lower bound {action_space.low}"
+        assert np.all(action <= action_space.high), f"Action {action} is above the upper bound {action_space.high}"
 
 
 def test_multidim_binary_not_supported():

--- a/tests/test_spaces.py
+++ b/tests/test_spaces.py
@@ -56,11 +56,20 @@ class DummyMultiDiscreteSpace(DummyEnv):
 class ActionBoundsTestClass(DummyEnv):
     def step(self, action):
         if isinstance(self.action_space, spaces.Discrete):
-            assert np.all(action >= self.action_space.start), f"Discrete action {action} is below the lower bound {self.action_space.start}"
-            assert np.all(action <= self.action_space.start + self.action_space.n), f"Discrete action {action} is above the upper bound {self.action_space.start}+{self.action_space.n}"
+            assert np.all(action >= self.action_space.start), (
+                f"Discrete action {action} is below the lower bound {self.action_space.start}")
+            assert np.all(action <= self.action_space.start + self.action_space.n), (
+                f"Discrete action {action} is above the upper bound {self.action_space.start}+{self.action_space.n}")
+        elif isinstance(self.action_space, spaces.MultiDiscrete):
+            assert np.all(action >= self.action_space.start), (
+                f"MultiDiscrete action {action} is below the lower bound {self.action_space.start}")
+            assert np.all(action <= self.action_space.start + self.action_space.nvec), (
+                f"MultiDiscrete action {action} is above the upper bound {self.action_space.start}+{self.action_space.nvec}")
         elif isinstance(self.action_space, spaces.Box):
-            assert np.all(action >= self.action_space.low), f"Action {action} is below the lower bound {self.action_space.low}"
-            assert np.all(action <= self.action_space.high), f"Action {action} is above the upper bound {self.action_space.high}"
+            assert np.all(action >= self.action_space.low), (
+                f"Action {action} is below the lower bound {self.action_space.low}")
+            assert np.all(action <= self.action_space.high), (
+                f"Action {action} is above the upper bound {self.action_space.high}")
         return self.observation_space.sample(), 0.0, False, False, {}
 
 @pytest.mark.parametrize(
@@ -184,6 +193,7 @@ def test_float64_action_space(model_class, obs_space, action_space):
         [
             # on-policy test
             (PPO, spaces.Discrete(5, start=-6543)),
+            (PPO, spaces.MultiDiscrete([4, 3], start=[-6543, 11])),
             (PPO, spaces.Box(low=2344, high=2345, shape=(3,), dtype=np.float32)),
             # off-policy test
             (DQN, spaces.Discrete(2, start=9923)),
@@ -210,11 +220,20 @@ def test_space_bounds(model_class, action_space):
 
     action, _ = model.predict(initial_obs, deterministic=False)
     if isinstance(action_space, spaces.Discrete):
-        assert np.all(action >= action_space.start), f"Discrete action {action} is below the lower bound {action_space.start}"
-        assert np.all(action <= action_space.start + action_space.n), f"Discrete action {action} is above the upper bound {action_space.start}+{action_space.n}"
+        assert np.all(action >= action_space.start), (
+            f"Discrete action {action} is below the lower bound {action_space.start}")
+        assert np.all(action <= action_space.start + action_space.n), (
+            f"Discrete action {action} is above the upper bound {action_space.start}+{action_space.n}")
+    elif isinstance(action_space, spaces.MultiDiscrete):
+        assert np.all(action >= action_space.start), (
+            f"MultiDiscrete action {action} is below the lower bound {action_space.start}")
+        assert np.all(action <= action_space.start + action_space.nvec), (
+            f"MultiDiscrete action {action} is above the upper bound {action_space.start}+{action_space.nvec}")
     elif isinstance(action_space, spaces.Box):
-        assert np.all(action >= action_space.low), f"Action {action} is below the lower bound {action_space.low}"
-        assert np.all(action <= action_space.high), f"Action {action} is above the upper bound {action_space.high}"
+        assert np.all(action >= action_space.low), (
+            f"Action {action} is below the lower bound {action_space.low}")
+        assert np.all(action <= action_space.high), (
+            f"Action {action} is above the upper bound {action_space.high}")
 
 
 def test_multidim_binary_not_supported():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This fixes the missing applying of start value of Discrete Space

The start value of "spaces.Discrete(3, start=-1)" has no effect and does not shift the space to given start value, even tough there are examples in the Discrete class like: observation_space = Discrete(3, start=-1, seed=42)  # {-1, 0, 1}
All Discrete Spaces start currently at zero.

## Motivation and Context
This is a bug-fix relating to https://github.com/DLR-RM/stable-baselines3/issues/2052, https://github.com/DLR-RM/stable-baselines3/issues/913, https://github.com/DLR-RM/stable-baselines3/issues/1295, https://github.com/DLR-RM/stable-baselines3/issues/1378
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->
- [x] I have raised an issue to propose this change ([required](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) for new features and bug fixes)

## Types of changes
**The start value of spaces.Discrete is added to the actions to properly shift space**
Reason for this position is, its the same position, the final scaling of spaces.Box happen. spaces.Discrete was never handled
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [No] New feature (non-breaking change which adds functionality)
- [No] Breaking change (fix or feature that would cause existing functionality to change)
- [No] Documentation (update in the documentation)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the changelog accordingly (**required**).
- [No] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [No] I have updated the documentation accordingly.
- [No] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary)
- [No] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary)
- [x] I have reformatted the code using `make format` (**required**)
- [x] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [x] I have ensured `make pytest` and `make type` both pass. (**required**)
- [x] I have checked that the documentation builds using `make doc` (**required**)

Note: You can run most of the checks using `make commit-checks`.

Note: we are using a maximum length of 127 characters per line

<!--- This Template is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->