### PR TITLE
Clarifying the documentation for custom env using images as observations

### DIFF
--- a/docs/guide/custom_env.rst
+++ b/docs/guide/custom_env.rst
@@ -9,8 +9,8 @@ That is to say, your environment must implement the following methods (and inher
 
 .. note::
 
-  If you are using images as input, the observation must be of type ``np.uint8`` and be contained in [0, 255].
-  By default, the observation is normalized by SB3 pre-processing (dividing by 255 to have values in [0, 1]) when using CNN policies.
+  If you are using images as input, the observation must be of type ``np.uint8`` and be within a space ``Box`` bounded by [0, 255] (``Box(low=0, high=255, shape=(<your image shape>)``).
+  By default, the observation is normalized by SB3 pre-processing (dividing by 255 to have values in [0, 1], i.e. ``Box(low=0, high=1)``) when using CNN policies.
   Images can be either channel-first or channel-last.
 
   If you want to use ``CnnPolicy`` or ``MultiInputPolicy`` with image-like observation (3D tensor) that are already normalized, you must pass ``normalize_images=False``


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
SB3 allows to use images as observations for custom environments. However, the current documentation is not 100% clear on the type of observation used. I believe that, especially since images' types are `np.uint8`, the clarity of the documentation can be enhanced by adding a minimal example, specifying that although the effective type seems to be discrete, images are handled through ``spaces.Box`` by SB3.

## Description
Minimal change in the custom env documentation guide.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) for new features and bug fixes)

See above. Mainly enhancing clarity of the documentation to work with custom environment defining images as input observations.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (update in the documentation)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**)
- [ ] I have updated the changelog accordingly (**required**).
- [x] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
- [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary)
- [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary)
- [ ] I have reformatted the code using `make format` (**required**)
- [ ] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [ ] I have ensured `make pytest` and `make type` both pass. (**required**)
- [x] I have checked that the documentation builds using `make doc` (**required**)

Note: You can run most of the checks using `make commit-checks`.

Note: we are using a maximum length of 127 characters per line

<!--- This Template is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->
