### PR TITLE
Optional BatchNorm integration in NatureCNN

### DIFF
--- a/examples/ppo_breakout_cnn.py
+++ b/examples/ppo_breakout_cnn.py
@@ -1,0 +1,36 @@
+from stable_baselines3 import PPO
+from stable_baselines3.common.env_util import make_atari_env
+from stable_baselines3.common.vec_env import VecFrameStack
+from stable_baselines3.common.evaluation import evaluate_policy
+import gymnasium as gym
+import ale_py        # the actual ALE backend
+import shimmy        # registers ALE-py with Gymnasium
+
+# 1. Create a vectorized Atari environment and stack frames
+env = make_atari_env("ALE/Breakout-v5", n_envs=4, seed=0)
+env = VecFrameStack(env, n_stack=4)
+
+# 2. Instantiate PPO with a CNN policy
+model = PPO(
+    policy="CnnPolicy",
+    env=env,
+    verbose=1
+)
+# 3. Train the agent
+model.learn(total_timesteps=200_000)
+
+# 4. Save the trained model
+model.save("ppo_breakout_cnn")
+
+# 5. Evaluate the trained agent
+mean_reward, std_reward = evaluate_policy(model, env, n_eval_episodes=10)
+print(f"Mean reward: {mean_reward:.2f} ± {std_reward:.2f}")
+
+# 6. (Optional) Run a few episodes and render
+obs = env.reset()
+for _ in range(10_000):
+    action, _states = model.predict(obs)
+    obs, rewards, dones, infos = env.step(action)
+    env.render()
+    if dones.any():
+        obs = env.reset()

--- a/stable_baselines3/common/torch_layers.py
+++ b/stable_baselines3/common/torch_layers.py
@@ -61,6 +61,7 @@ class NatureCNN(BaseFeaturesExtractor):
         the space is a Box and has 3 dimensions.
         Otherwise, it checks that it has expected dtype (uint8) and bounds (values in [0, 255]).
     """
+
     def __init__(
         self,
         observation_space: gym.Space,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added an optional `BatchNorm` integration to the `NatureCNN` architecture used in the feature extractor module of Stable-Baselines3. This enhancement introduces a `use_batch_norm` flag to toggle Batch Normalization after each convolutional layer. This change provides a performance and stability improvement option for image-based environments.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change will solve the exploding gradients problem and in case it is set to False it does not change anything, however if set to True it will help converge much faster and enables us to use higher learning rates.
Further than that this change allows users to optionally enable Batch Normalization in NatureCNN, which can improve training stability and convergence, especially in environments with high variance in pixel input. I initially explored alternatives (LayerNorm, GroupNorm). BatchNorm showed the best trade-off of speed and stability and convergence.

<!--- If it fixes an open issue, please link to the issue here. --> N/A
<!--- You can use the syntax `closes #100` if this solves the issue #100 --> N/A
- [ ] I have raised an issue to propose this change ([#2128](https://github.com/DLR-RM/stable-baselines3/issues/2131) for new features and bug fixes)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (update in the documentation)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
- [x] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary)
- [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary)
- [x] I have reformatted the code using `make format` (**required**)
- [x] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [x] I have ensured `make pytest` and `make type` both pass. (**required**)
- [x] I have checked that the documentation builds using `make doc` (**required**)

Note: You can run most of the checks using `make commit-checks`.

Note: we are using a maximum length of 127 characters per line

<!--- This Template is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->
