### PR TITLE
Update LunarLander and LunarLanderContinuous Environments from v2 to v3 in the Documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,8 @@ jobs:
         run: |
           uv pip install --system gymnasium==${{ matrix.gymnasium-version }}
           uv pip install --system "numpy<2"
-        # Only run for python 3.10, downgrade gym to 0.29.1, numpy<2
+          uv pip install --system "ale-py==0.10.1"
+        # Only run for python 3.10, downgrade gym to 0.29.1, numpy<2, ale-py==0.10.1
         if: matrix.gymnasium-version != '1.0.0'
       - name: Lint with ruff
         run: |

--- a/docs/guide/examples.rst
+++ b/docs/guide/examples.rst
@@ -71,7 +71,7 @@ In the following example, we will train, save and load a DQN model on the Lunar 
 
 
   # Create environment
-  env = gym.make("LunarLander-v2", render_mode="rgb_array")
+  env = gym.make("LunarLander-v3", render_mode="rgb_array")
 
   # Instantiate the agent
   model = DQN("MlpPolicy", env, verbose=1)
@@ -289,7 +289,7 @@ If your callback returns False, training is aborted early.
   os.makedirs(log_dir, exist_ok=True)
 
   # Create and wrap the environment
-  env = gym.make("LunarLanderContinuous-v2")
+  env = gym.make("LunarLanderContinuous-v3")
   env = Monitor(env, log_dir)
 
   # Add some action noise for exploration
@@ -816,7 +816,7 @@ Bonus: Make a GIF of a Trained Agent
 
   from stable_baselines3 import A2C
 
-  model = A2C("MlpPolicy", "LunarLander-v2").learn(100_000)
+  model = A2C("MlpPolicy", "LunarLander-v3").learn(100_000)
 
   images = []
   obs = model.env.reset()

--- a/docs/guide/integrations.rst
+++ b/docs/guide/integrations.rst
@@ -73,11 +73,11 @@ Installation
 
      # Download model and save it into the logs/ folder
      # Only use TRUST_REMOTE_CODE=True with HF models that can be trusted (here the SB3 organization)
-     TRUST_REMOTE_CODE=True python -m rl_zoo3.load_from_hub --algo a2c --env LunarLander-v2 -orga sb3 -f logs/
+     TRUST_REMOTE_CODE=True python -m rl_zoo3.load_from_hub --algo a2c --env LunarLander-v3 -orga sb3 -f logs/
      # Test the agent
-     python -m rl_zoo3.enjoy --algo a2c --env LunarLander-v2  -f logs/
+     python -m rl_zoo3.enjoy --algo a2c --env LunarLander-v3  -f logs/
      # Push model, config and hyperparameters to the hub
-     python -m rl_zoo3.push_to_hub --algo a2c --env LunarLander-v2 -f logs/ -orga sb3 -m "Initial commit"
+     python -m rl_zoo3.push_to_hub --algo a2c --env LunarLander-v3 -f logs/ -orga sb3 -m "Initial commit"
 
 
 

--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -37,7 +37,7 @@ Documentation:
 ^^^^^^^^^^^^^^
 - Clarify ``evaluate_policy`` documentation
 - Added doc about training exceeding the `total_timesteps` parameter
-- Updated ``LunarLander`` and ``LunarLanderContinuous`` environment versions to v3
+- Updated ``LunarLander`` and ``LunarLanderContinuous`` environment versions to v3 (@j0m0k0)
 
 
 Release 2.6.0 (2025-03-24)

--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -37,6 +37,7 @@ Documentation:
 ^^^^^^^^^^^^^^
 - Clarify ``evaluate_policy`` documentation
 - Added doc about training exceeding the `total_timesteps` parameter
+- Updated ``LunarLander`` and ``LunarLanderContinuous`` environment versions to v3
 
 
 Release 2.6.0 (2025-03-24)

--- a/stable_baselines3/common/policies.py
+++ b/stable_baselines3/common/policies.py
@@ -381,7 +381,7 @@ class BasePolicy(BaseModel, ABC):
         # Remove batch dimension if needed
         if not vectorized_env:
             assert isinstance(actions, np.ndarray)
-            actions = actions.squeeze(axis=0)
+            actions = actions.squeeze(axis=0)  # type: ignore[assignment]
 
         return actions, state  # type: ignore[return-value]
 


### PR DESCRIPTION
Update LunarLander and LunarLanderCountinuous versions from v2 to v3.

<!--- Provide a general summary of your changes in the Title above -->

## Description
The version 2 of `LunarLander` and `LunarLanderContinuous` environments are deprecated by gymnasium. Running the examples throws the `DeprecatedEnv` error and the examples could not run successfully. A slight change can fix this issue. We need to update the versions of these environments in the code from v2 to v3. I have already searched for all the usages of these environments in the documentation and updated all of them in this PR.

For reproducing the problem, just run the examples with the latest stable version of gymnasium and you'll see these errors:

```bash
    raise error.DeprecatedEnv(
    ...<2 lines>...
    )
gymnasium.error.DeprecatedEnv: Environment version v2 for `LunarLander` is deprecated. Please use `LunarLander-v3` instead.
```

And 
```bash
    raise error.DeprecatedEnv(
    ...<2 lines>...
    )
gymnasium.error.DeprecatedEnv: Environment version v2 for `LunarLanderContinuous` is deprecated. Please use `LunarLanderContinuous-v3` instead.
```
## Motivation and Context
This change is important to make sure users (specially newer users) can follow the tutorials without a hassle. Without this update, running the examples with raise the following error:
```
gymnasium.error.DeprecatedEnv: Environment version v2 for `LunarLander` is deprecated. Please use `LunarLander-v3` instead.
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation (update in the documentation)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**)
- [X] I have updated the changelog accordingly (**required**).
- [X] My change requires a change to the documentation.
- [X] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [X] I have updated the documentation accordingly.
- [X] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary)
- [X] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary)
- [X] I have reformatted the code using `make format` (**required**)
- [X] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [X] I have ensured `make pytest` and `make type` both pass. (**required**)
- [X] I have checked that the documentation builds using `make doc` (**required**)

Note: You can run most of the checks using `make commit-checks`.

Note: we are using a maximum length of 127 characters per line

<!--- This Template is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->
