### PR TITLE
tests: add reproducibility tests for set_random_seed

### DIFF
--- a/tests/test_utils_seed.py
+++ b/tests/test_utils_seed.py
@@ -1,0 +1,42 @@
+import random
+import numpy as np
+import torch
+
+from stable_baselines3.common.utils import set_random_seed
+
+
+def test_set_random_seed_reproducibility():
+    """
+    Ensure that calling set_random_seed with the same seed produces identical
+    outputs from random, numpy and torch across repeated calls.
+    """
+    seed = 12345
+
+    set_random_seed(seed)
+    r1 = random.random()
+    n1 = np.random.rand(3)
+    t1 = torch.randn(3)
+
+    # Reset with the same seed and sample again
+    set_random_seed(seed)
+    r2 = random.random()
+    n2 = np.random.rand(3)
+    t2 = torch.randn(3)
+
+    assert r1 == r2, "Python random produced different results for identical seed"
+    assert np.allclose(n1, n2), "NumPy produced different results for identical seed"
+    assert torch.allclose(t1, t2), "Torch produced different results for identical seed"
+
+
+def test_set_random_seed_differs_for_different_seeds():
+    """
+    Ensure that using different seeds results in different sequences (basic sanity check).
+    """
+    set_random_seed(1)
+    a1 = np.random.rand(5)
+
+    set_random_seed(2)
+    a2 = np.random.rand(5)
+
+    # It's extremely unlikely two different seeds produce the exact same float arrays
+    assert not np.allclose(a1, a2), "Different seeds produced identical NumPy sequences"


### PR DESCRIPTION
# Pull Request: tests: add reproducibility tests for set_random_seed

<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds a small test file that verifies `stable_baselines3.common.utils.set_random_seed` correctly seeds Python's `random`, NumPy and PyTorch RNGs.

Files added
- `tests/test_utils_seed.py` (new)

What the tests do
- `test_set_random_seed_reproducibility`: calling `set_random_seed` with the same seed produces identical outputs across repeated calls for `random`, `numpy` and `torch`.
- `test_set_random_seed_differs_for_different_seeds`: different seeds produce different NumPy sequences (basic sanity check).

This is a tests-only change; no runtime or API behavior is modified.

## Motivation and Context
These tests guard against regressions where one RNG (Python `random`, `numpy`, or `torch`) is not seeded properly. Such regressions can cause non-deterministic or flaky behaviour in training and evaluation. Adding small, focused tests increases confidence that `set_random_seed` continues to seed all intended RNGs.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Tests (adds/updates tests only)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I've read the [CONTRIBUTING](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide
- [ ] I have updated the changelog accordingly (not required for tests-only PR)
- [ ] My change requires a change to the documentation
- [x] I have updated the tests accordingly (tests added)
- [ ] I have updated the documentation accordingly
- [ ] I have opened an associated PR on the SB3-Contrib repository (if necessary)
- [ ] I have opened an associated PR on the RL-Zoo3 repository (if necessary)
- [ ] I have reformatted the code using `make format` (recommended)
- [ ] I have checked the codestyle using `make check-codestyle` and `make lint` (recommended)
- [ ] I have ensured `make pytest` and `make type` both pass (recommended)
- [ ] I have checked that the documentation builds using `make doc` (only relevant for docs changes)

## How to run the new test locally
1. (Recommended) Create and activate a virtual environment:
   ```bash
   python -m venv .venv
   source .venv/bin/activate   # Windows: .venv\Scripts\activate
   pip install -U pip setuptools wheel
   ```

2. Install project dev dependencies (editable install):
   ```bash
   pip install -e '.[docs,tests,extra]'
   ```

   If `torch` is not installed by the extras or you want a CPU-only install:
   ```bash
   pip install torch --index-url https://download.pytorch.org/whl/cpu
   ```

3. Ensure `gymnasium` is installed if needed:
   ```bash
   pip install gymnasium
   ```

4. Run just the new test:
   - On Linux/macOS:
     ```bash
     export CUDA_VISIBLE_DEVICES=""
     pytest -q tests/test_utils_seed.py
     ```
   - On Windows (PowerShell):
     ```powershell
     $env:CUDA_VISIBLE_DEVICES=""
     pytest -q tests/test_utils_seed.py
     ```

Expected result: `2 passed` (the test file contains two tests).

## Additional notes
- This PR adds tests only and does not change public API or behavior.
- If maintainers request, I can add a GPU-conditional test for `torch.cuda` seeding (skipped automatically when CUDA is not available).
