### PR TITLE
docs: add minimal EvalCallback example

### DIFF
--- a/docs/guide/callbacks.rst
+++ b/docs/guide/callbacks.rst
@@ -132,6 +132,36 @@ A child callback is for instance :ref:`StopTrainingOnRewardThreshold <StopTraini
 
         def _on_event(self) -> bool:
             return self.callback()
+        
+Minimal evaluation during training (EvalCallback)
+--------------------------------------------------
+
+It is good practice to evaluate an agent on a separate environment while training.
+Using a dedicated ``eval_env`` keeps evaluation metrics reliable and avoids
+interfering with the training process.
+
+The following example shows how to periodically evaluate a PPO agent and
+save the best-performing model during training:
+
+.. code-block:: python
+
+    import gymnasium as gym
+    from stable_baselines3 import PPO
+    from stable_baselines3.common.callbacks import EvalCallback
+
+    env = gym.make("CartPole-v1")
+    eval_env = gym.make("CartPole-v1")
+
+    eval_callback = EvalCallback(
+        eval_env,
+        best_model_save_path="./logs/",
+        log_path="./logs/",
+        eval_freq=5_000,
+        deterministic=True,
+    )
+
+    model = PPO("MlpPolicy", env, verbose=1)
+    model.learn(total_timesteps=50_000, callback=eval_callback)
 
 
 Callback Collection


### PR DESCRIPTION
## Description
This PR adds a minimal, self-contained example demonstrating how to use
`EvalCallback` to periodically evaluate an agent during training and save
the best-performing model.

The example focuses on a common beginner use case and highlights the use
of a separate evaluation environment to keep metrics reliable.

## Motivation and Context
While `EvalCallback` is referenced in the callbacks documentation, there was
no concise, end-to-end example showing how to use it in practice.
This addition makes it easier for new users to correctly evaluate agents
during training without interfering with the learning process.

- [ ] I have raised an issue to propose this change (not required for documentation updates)

## Types of changes
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation (update in the documentation)

## Checklist
- [x] I've read the CONTRIBUTION guide
- [ ] I have updated the changelog accordingly (not required for documentation-only changes)
- [x] My change requires a change to the documentation
- [ ] I have updated the tests accordingly (not required for documentation-only changes)
- [x] I have updated the documentation accordingly
- [ ] I have opened an associated PR on the SB3-Contrib repository (not necessary)
- [ ] I have opened an associated PR on the RL-Zoo3 repository (not necessary)
- [ ] I have reformatted the code using `make format` (not required for documentation-only changes)
- [ ] I have checked the codestyle using `make check-codestyle` and `make lint` (not required)
- [ ] I have ensured `make pytest` and `make type` both pass (not required)
- [x] I have checked that the documentation builds using `make html`