### PR TITLE
fix: pass reset options/seeds during auto-reset on termination

### DIFF
--- a/stable_baselines3/common/vec_env/dummy_vec_env.py
+++ b/stable_baselines3/common/vec_env/dummy_vec_env.py
@@ -68,7 +68,10 @@ class DummyVecEnv(VecEnv):
             if self.buf_dones[env_idx]:
                 # save final observation where user can get it, then reset
                 self.buf_infos[env_idx]["terminal_observation"] = obs
-                obs, self.reset_infos[env_idx] = self.envs[env_idx].reset()
+                maybe_options = {"options": self._options[env_idx]} if self._options[env_idx] else {}
+                obs, self.reset_infos[env_idx] = self.envs[env_idx].reset(
+                    seed=self._seeds[env_idx], **maybe_options
+                )
             self._save_obs(env_idx, obs)
         return (self._obs_from_buf(), np.copy(self.buf_rews), np.copy(self.buf_dones), deepcopy(self.buf_infos))
 

--- a/stable_baselines3/common/vec_env/subproc_vec_env.py
+++ b/stable_baselines3/common/vec_env/subproc_vec_env.py
@@ -32,14 +32,16 @@ def _worker(  # noqa: C901
         try:
             cmd, data = remote.recv()
             if cmd == "step":
-                observation, reward, terminated, truncated, info = env.step(data)
+                action, seed, options = data
+                observation, reward, terminated, truncated, info = env.step(action)
                 # convert to SB3 VecEnv api
                 done = terminated or truncated
                 info["TimeLimit.truncated"] = truncated and not terminated
                 if done:
                     # save final observation where user can get it, then reset
                     info["terminal_observation"] = observation
-                    observation, reset_info = env.reset()
+                    maybe_options = {"options": options} if options else {}
+                    observation, reset_info = env.reset(seed=seed, **maybe_options)
                 remote.send((observation, reward, done, info, reset_info))
             elif cmd == "reset":
                 maybe_options = {"options": data[1]} if data[1] else {}
@@ -129,8 +131,8 @@ class SubprocVecEnv(VecEnv):
         super().__init__(len(env_fns), observation_space, action_space)
 
     def step_async(self, actions: np.ndarray) -> None:
-        for remote, action in zip(self.remotes, actions, strict=True):
-            remote.send(("step", action))
+        for env_idx, (remote, action) in enumerate(zip(self.remotes, actions, strict=True)):
+            remote.send(("step", (action, self._seeds[env_idx], self._options[env_idx])))
         self.waiting = True
 
     def step_wait(self) -> VecEnvStepReturn:

--- a/tests/test_vec_envs.py
+++ b/tests/test_vec_envs.py
@@ -215,6 +215,42 @@ def test_vecenv_custom_calls(vec_env_class, vec_env_wrapper):
     vec_env.close()
 
 
+@pytest.mark.parametrize("vec_env_class", VEC_ENV_CLASSES)
+def test_vecenv_options_on_termination_reset(vec_env_class):
+    """Test that options and seeds set via set_options() are passed
+    to the environment when it auto-resets due to episode termination
+    during step(). See GH#1790."""
+
+    def make_env():
+        env = CustomGymEnv(spaces.Box(low=-1, high=1, shape=(2,), dtype=np.float32))
+        # Use short episodes so termination happens quickly
+        env.ep_length = 2
+        return env
+
+    vec_env = vec_env_class([make_env for _ in range(N_ENVS)])
+
+    # First do an explicit reset (no options)
+    vec_env.reset()
+    assert vec_env.get_attr("current_options") == [None] * N_ENVS
+
+    # Now set options AFTER reset — these should be used when step() triggers auto-reset
+    options = {"test_option": 42}
+    vec_env.set_options(options)
+
+    # Step until episode terminates (ep_length=2, so 2 steps triggers truncation)
+    for _ in range(2):
+        vec_env.step([vec_env.action_space.sample() for _ in range(N_ENVS)])
+
+    # After auto-reset from termination, options should have been passed
+    current_options = vec_env.get_attr("current_options")
+    assert current_options == [options] * N_ENVS, (
+        f"Options were not passed during auto-reset on termination. "
+        f"Expected {[options] * N_ENVS}, got {current_options}"
+    )
+
+    vec_env.close()
+
+
 class StepEnv(gym.Env):
     def __init__(self, max_steps):
         """Gym environment for testing that terminal observation is inserted


### PR DESCRIPTION
## Summary
- Fixes #1790: `set_options()` and `seed()` values were ignored when environments auto-reset due to episode termination/truncation inside `step()` 
- Passes stored `_options` and `_seeds` to `env.reset()` during auto-reset in both `DummyVecEnv.step_wait()` and `SubprocVecEnv._worker()`
- Adds test `test_vecenv_options_on_termination_reset` covering both vec env classes

## Changes

### `DummyVecEnv.step_wait()` 
Previously called `self.envs[env_idx].reset()` with no arguments on termination. Now passes `seed` and `options`:
```python
maybe_options = {"options": self._options[env_idx]} if self._options[env_idx] else {}
obs, self.reset_infos[env_idx] = self.envs[env_idx].reset(
    seed=self._seeds[env_idx], **maybe_options
)
```

### `SubprocVecEnv._worker()` 
The worker's `"step"` command now receives `(action, seed, options)` instead of just `action`, and passes them to `env.reset()` on termination.

### `SubprocVecEnv.step_async()`
Sends `(action, seed, options)` tuple to each worker process.

## Design Note
Options/seeds remain available across multiple auto-resets until explicitly cleared by a call to `reset()` (which calls `_reset_seeds()` and `_reset_options()`). This matches the behavior described in the issue — options set via `set_options()` should apply whenever the env resets, whether explicitly or via termination.

## Test plan
- [x] Added `test_vecenv_options_on_termination_reset` for both `DummyVecEnv` and `SubprocVecEnv`
- [x] All 35 existing tests in `test_vec_envs.py` pass (3 skipped: render/video)