### PR TITLE
feat: add qf_learning_rate for independent actor/critic LRs

### DIFF
--- a/stable_baselines3/ddpg/ddpg.py
+++ b/stable_baselines3/ddpg/ddpg.py
@@ -26,6 +26,8 @@ class DDPG(TD3):
     :param learning_rate: learning rate for adam optimizer,
         the same learning rate will be used for all networks (Q-Values, Actor and Value function)
         it can be a function of the current progress remaining (from 1 to 0)
+    :param qf_learning_rate: learning rate for the critic (Q-value function) optimizer.
+        If ``None``, the same ``learning_rate`` is used for both actor and critic.
     :param buffer_size: size of the replay buffer
     :param learning_starts: how many steps of the model to collect transitions for before learning starts
     :param batch_size: Minibatch size for each gradient update
@@ -59,6 +61,7 @@ class DDPG(TD3):
         policy: str | type[TD3Policy],
         env: GymEnv | str,
         learning_rate: float | Schedule = 1e-3,
+        qf_learning_rate: float | None = None,
         buffer_size: int = 1_000_000,  # 1e6
         learning_starts: int = 100,
         batch_size: int = 256,
@@ -82,6 +85,7 @@ class DDPG(TD3):
             policy=policy,
             env=env,
             learning_rate=learning_rate,
+            qf_learning_rate=qf_learning_rate,
             buffer_size=buffer_size,
             learning_starts=learning_starts,
             batch_size=batch_size,

--- a/stable_baselines3/sac/sac.py
+++ b/stable_baselines3/sac/sac.py
@@ -10,7 +10,7 @@ from stable_baselines3.common.noise import ActionNoise
 from stable_baselines3.common.off_policy_algorithm import OffPolicyAlgorithm
 from stable_baselines3.common.policies import BasePolicy, ContinuousCritic
 from stable_baselines3.common.type_aliases import GymEnv, MaybeCallback, Schedule
-from stable_baselines3.common.utils import get_parameters_by_name, polyak_update
+from stable_baselines3.common.utils import get_parameters_by_name, polyak_update, update_learning_rate
 from stable_baselines3.sac.policies import Actor, CnnPolicy, MlpPolicy, MultiInputPolicy, SACPolicy
 
 SelfSAC = TypeVar("SelfSAC", bound="SAC")
@@ -35,6 +35,8 @@ class SAC(OffPolicyAlgorithm):
     :param learning_rate: learning rate for adam optimizer,
         the same learning rate will be used for all networks (Q-Values, Actor and Value function)
         it can be a function of the current progress remaining (from 1 to 0)
+    :param qf_learning_rate: learning rate for the critic (Q-value function) optimizer.
+        If ``None``, the same ``learning_rate`` is used for both actor and critic.
     :param buffer_size: size of the replay buffer
     :param learning_starts: how many steps of the model to collect transitions for before learning starts
     :param batch_size: Minibatch size for each gradient update
@@ -93,6 +95,7 @@ class SAC(OffPolicyAlgorithm):
         policy: str | type[SACPolicy],
         env: GymEnv | str,
         learning_rate: float | Schedule = 3e-4,
+        qf_learning_rate: float | None = None,
         buffer_size: int = 1_000_000,  # 1e6
         learning_starts: int = 100,
         batch_size: int = 256,
@@ -155,6 +158,7 @@ class SAC(OffPolicyAlgorithm):
         self.ent_coef = ent_coef
         self.target_update_interval = target_update_interval
         self.ent_coef_optimizer: th.optim.Adam | None = None
+        self.qf_learning_rate = qf_learning_rate
 
         if _init_setup_model:
             self._setup_model()
@@ -194,6 +198,10 @@ class SAC(OffPolicyAlgorithm):
             # is passed
             self.ent_coef_tensor = th.tensor(float(self.ent_coef), device=self.device)
 
+        # Set the initial critic learning rate if qf_learning_rate is specified
+        if self.qf_learning_rate is not None:
+            update_learning_rate(self.critic.optimizer, self.qf_learning_rate)
+
     def _create_aliases(self) -> None:
         self.actor = self.policy.actor
         self.critic = self.policy.critic
@@ -202,13 +210,20 @@ class SAC(OffPolicyAlgorithm):
     def train(self, gradient_steps: int, batch_size: int = 64) -> None:
         # Switch to train mode (this affects batch norm / dropout)
         self.policy.set_training_mode(True)
-        # Update optimizers learning rate
-        optimizers = [self.actor.optimizer, self.critic.optimizer]
-        if self.ent_coef_optimizer is not None:
-            optimizers += [self.ent_coef_optimizer]
-
         # Update learning rate according to lr schedule
-        self._update_learning_rate(optimizers)
+        if self.qf_learning_rate is not None:
+            # Actor (and ent_coef) follows the schedule, critic uses a constant learning rate
+            optimizers = [self.actor.optimizer]
+            if self.ent_coef_optimizer is not None:
+                optimizers += [self.ent_coef_optimizer]
+            self._update_learning_rate(optimizers)
+            update_learning_rate(self.critic.optimizer, self.qf_learning_rate)
+            self.logger.record("train/qf_learning_rate", self.qf_learning_rate)
+        else:
+            optimizers = [self.actor.optimizer, self.critic.optimizer]
+            if self.ent_coef_optimizer is not None:
+                optimizers += [self.ent_coef_optimizer]
+            self._update_learning_rate(optimizers)
 
         ent_coef_losses, ent_coefs = [], []
         actor_losses, critic_losses = [], []

--- a/stable_baselines3/td3/td3.py
+++ b/stable_baselines3/td3/td3.py
@@ -10,7 +10,7 @@ from stable_baselines3.common.noise import ActionNoise
 from stable_baselines3.common.off_policy_algorithm import OffPolicyAlgorithm
 from stable_baselines3.common.policies import BasePolicy, ContinuousCritic
 from stable_baselines3.common.type_aliases import GymEnv, MaybeCallback, Schedule
-from stable_baselines3.common.utils import get_parameters_by_name, polyak_update
+from stable_baselines3.common.utils import get_parameters_by_name, polyak_update, update_learning_rate
 from stable_baselines3.td3.policies import Actor, CnnPolicy, MlpPolicy, MultiInputPolicy, TD3Policy
 
 SelfTD3 = TypeVar("SelfTD3", bound="TD3")
@@ -30,6 +30,8 @@ class TD3(OffPolicyAlgorithm):
     :param learning_rate: learning rate for adam optimizer,
         the same learning rate will be used for all networks (Q-Values, Actor and Value function)
         it can be a function of the current progress remaining (from 1 to 0)
+    :param qf_learning_rate: learning rate for the critic (Q-value function) optimizer.
+        If ``None``, the same ``learning_rate`` is used for both actor and critic.
     :param buffer_size: size of the replay buffer
     :param learning_starts: how many steps of the model to collect transitions for before learning starts
     :param batch_size: Minibatch size for each gradient update
@@ -82,6 +84,7 @@ class TD3(OffPolicyAlgorithm):
         policy: str | type[TD3Policy],
         env: GymEnv | str,
         learning_rate: float | Schedule = 1e-3,
+        qf_learning_rate: float | None = None,
         buffer_size: int = 1_000_000,  # 1e6
         learning_starts: int = 100,
         batch_size: int = 256,
@@ -135,6 +138,7 @@ class TD3(OffPolicyAlgorithm):
         self.policy_delay = policy_delay
         self.target_noise_clip = target_noise_clip
         self.target_policy_noise = target_policy_noise
+        self.qf_learning_rate = qf_learning_rate
 
         if _init_setup_model:
             self._setup_model()
@@ -148,6 +152,10 @@ class TD3(OffPolicyAlgorithm):
         self.actor_batch_norm_stats_target = get_parameters_by_name(self.actor_target, ["running_"])
         self.critic_batch_norm_stats_target = get_parameters_by_name(self.critic_target, ["running_"])
 
+        # Set the initial critic learning rate if qf_learning_rate is specified
+        if self.qf_learning_rate is not None:
+            update_learning_rate(self.critic.optimizer, self.qf_learning_rate)
+
     def _create_aliases(self) -> None:
         self.actor = self.policy.actor
         self.actor_target = self.policy.actor_target
@@ -159,7 +167,13 @@ class TD3(OffPolicyAlgorithm):
         self.policy.set_training_mode(True)
 
         # Update learning rate according to lr schedule
-        self._update_learning_rate([self.actor.optimizer, self.critic.optimizer])
+        if self.qf_learning_rate is not None:
+            # Actor follows the schedule, critic uses a constant learning rate
+            self._update_learning_rate([self.actor.optimizer])
+            update_learning_rate(self.critic.optimizer, self.qf_learning_rate)
+            self.logger.record("train/qf_learning_rate", self.qf_learning_rate)
+        else:
+            self._update_learning_rate([self.actor.optimizer, self.critic.optimizer])
 
         actor_losses, critic_losses = [], []
         for _ in range(gradient_steps):

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -87,6 +87,38 @@ def test_sac(ent_coef):
     model.learn(total_timesteps=200)
 
 
+@pytest.mark.parametrize("model_class", [TD3, DDPG, SAC])
+def test_qf_learning_rate(model_class):
+    """Test that independent critic learning rate (qf_learning_rate) works correctly.
+    See GH#338."""
+    actor_lr = 1e-4
+    critic_lr = 1e-3
+
+    model = model_class(
+        "MlpPolicy",
+        "Pendulum-v1",
+        learning_rate=actor_lr,
+        qf_learning_rate=critic_lr,
+        policy_kwargs=dict(net_arch=[64, 64]),
+        learning_starts=100,
+        buffer_size=250,
+        verbose=1,
+    )
+
+    # Check that the initial learning rates are set correctly
+    actor_optimizer_lr = model.actor.optimizer.param_groups[0]["lr"]
+    critic_optimizer_lr = model.critic.optimizer.param_groups[0]["lr"]
+    assert actor_optimizer_lr == actor_lr, f"Actor LR should be {actor_lr}, got {actor_optimizer_lr}"
+    assert critic_optimizer_lr == critic_lr, f"Critic LR should be {critic_lr}, got {critic_optimizer_lr}"
+
+    # Train and verify the learning rates are maintained
+    model.learn(total_timesteps=200)
+
+    # After training, actor LR may change (if using schedule), but critic LR should stay constant
+    critic_optimizer_lr = model.critic.optimizer.param_groups[0]["lr"]
+    assert critic_optimizer_lr == critic_lr, f"Critic LR should remain {critic_lr}, got {critic_optimizer_lr}"
+
+
 @pytest.mark.parametrize("n_critics", [1, 3])
 def test_n_critics(n_critics):
     # Test SAC with different number of critics, for TD3, n_critics=1 corresponds to DDPG


### PR DESCRIPTION
## Summary
- Adds `qf_learning_rate` parameter to **TD3**, **SAC**, and **DDPG** for configuring a separate constant learning rate for the critic optimizer
- When `None` (default), behavior is unchanged — fully backward compatible
- Follows the same pattern used in [SBX](https://github.com/araffin/sbx) as suggested by @araffin in #338

Closes #338

## Usage
```python
from stable_baselines3 import TD3, SAC, DDPG

# Actor uses 3e-4 (with schedule support), critic uses constant 1e-3
model = TD3("MlpPolicy", "Pendulum-v1", learning_rate=3e-4, qf_learning_rate=1e-3)

# Also works with SAC and DDPG
model = SAC("MlpPolicy", "Pendulum-v1", learning_rate=3e-4, qf_learning_rate=1e-3)
model = DDPG("MlpPolicy", "Pendulum-v1", learning_rate=3e-4, qf_learning_rate=1e-3)
```

## Changes
- **`td3/td3.py`**: Added `qf_learning_rate` parameter, set initial critic LR in `_setup_model()`, update actor/critic LRs separately in `train()`
- **`sac/sac.py`**: Same pattern as TD3, also handles `ent_coef_optimizer` correctly (follows actor schedule, not critic LR)
- **`ddpg/ddpg.py`**: Passes `qf_learning_rate` through to TD3 (since DDPG inherits TD3)
- **`tests/test_run.py`**: Added `test_qf_learning_rate` covering all three algorithms

## Design decisions
- `qf_learning_rate` is a **constant float**, not a schedule (matching SBX behavior). The actor's `learning_rate` still supports schedules.
- When `qf_learning_rate` is set, `train/qf_learning_rate` is logged separately in TensorBoard alongside `train/learning_rate` (actor)
- SAC's `ent_coef_optimizer` follows the actor schedule (not the critic LR), as it controls exploration, not Q-value estimation

## Test plan
- [x] Added `test_qf_learning_rate` parametrized for TD3, DDPG, SAC — verifies initial LR, trains, and checks critic LR stays constant
- [x] All 38 tests in `test_run.py` pass
- [x] Backward compatible — default `qf_learning_rate=None` preserves existing behavior