### PR TITLE
fix is_image_space docs for frame-stacked observations

### DIFF
--- a/docs/guide/custom_env.md
+++ b/docs/guide/custom_env.md
@@ -20,6 +20,28 @@ Although SB3 supports both channel-last and channel-first images as input, we re
 Under the hood, when a channel-last image is passed, SB3 uses a `VecTransposeImage` wrapper to re-order the channels.
 :::
 
+:::{warning}
+Gymnasium's `FrameStackObservation` wrapper adds an extra dimension to the observation space
+(e.g., `(3, 64, 64)` becomes `(2, 3, 64, 64)` with `stack_size=2`), which causes SB3's `is_image_space`
+to no longer recognize the observation as an image. This means the `CnnPolicy` feature extractor won't be
+selected automatically.
+
+Use SB3's `VecFrameStack` wrapper instead, which stacks frames along the channel dimension
+(e.g., `(3, 64, 64)` becomes `(6, 64, 64)` with `n_stack=2`), keeping the observation compatible
+with `is_image_space`. See [issue #2090](https://github.com/DLR-RM/stable-baselines3/issues/2090)
+and [issue #1500](https://github.com/DLR-RM/stable-baselines3/issues/1500) for more details.
+
+```python
+from stable_baselines3.common.vec_env import DummyVecEnv, VecFrameStack
+
+env = DummyVecEnv([lambda: env])
+env = VecFrameStack(env, n_stack=2)
+```
+
+Alternatively, if you cannot use `VecFrameStack`, you can use Gymnasium's `TransformObservation`
+wrapper to reshape the stacked observation back to 3 dimensions (merging the stack and channel dimensions).
+:::
+
 :::{note}
 SB3 doesn't support `Discrete` and `MultiDiscrete` spaces with `start!=0`. However, you can update your environment or use a wrapper to make your env compatible with SB3:
 

--- a/stable_baselines3/common/preprocessing.py
+++ b/stable_baselines3/common/preprocessing.py
@@ -35,6 +35,14 @@ def is_image_space(
 
     Valid images: RGB, RGBD, GrayScale with values in [0, 255]
 
+    .. note::
+
+        This function expects exactly 3 dimensions (HxWxC or CxHxW).
+        Gymnasium's ``FrameStackObservation`` wrapper adds an extra stacking dimension,
+        which will cause this check to return False. Use SB3's ``VecFrameStack``
+        instead, which stacks along the channel dimension.
+        See https://github.com/DLR-RM/stable-baselines3/issues/2090
+
     :param observation_space:
     :param check_channels: Whether to do or not the check for the number of channels.
         e.g., with frame-stacking, the observation space may have more channels than expected.


### PR DESCRIPTION
added a warning in the custom environments docs about gymnasium's FrameStackObservation adding an extra dimension that breaks is_image_space, and a note in the docstring itself. fixes #2090