### PR TITLE
Fix is_image_space for frame-stacked observations

### DIFF
--- a/stable_baselines3/common/preprocessing.py
+++ b/stable_baselines3/common/preprocessing.py
@@ -11,13 +11,18 @@ def is_image_space_channels_first(observation_space: spaces.Box) -> bool:
     Check if an image observation space (see ``is_image_space``)
     is channels-first (CxHxW, True) or channels-last (HxWxC, False).
 
-    Use a heuristic that channel dimension is the smallest of the three.
-    If second dimension is smallest, raise an exception (no support).
+    Use a heuristic that channel dimension is the smallest of the last three dimensions.
+    If the middle dimension (of the last three) is smallest, raise a warning (no support).
+
+    For higher-dimensional spaces (e.g., frame-stacked observations with shape
+    ``(stack, C, H, W)``), only the last three dimensions are considered.
 
     :param observation_space:
     :return: True if observation space is channels-first image, False if channels-last.
     """
-    smallest_dimension = np.argmin(observation_space.shape).item()
+    # Only consider the last 3 dimensions (image part) for channel detection
+    image_shape = observation_space.shape[-3:]
+    smallest_dimension = np.argmin(image_shape).item()
     if smallest_dimension == 1:
         warnings.warn("Treating image space as channels-last, while second dimension was smallest of the three.")
     return smallest_dimension == 0
@@ -35,17 +40,21 @@ def is_image_space(
 
     Valid images: RGB, RGBD, GrayScale with values in [0, 255]
 
+    Supports higher-dimensional spaces such as frame-stacked observations
+    (e.g., shape ``(stack, C, H, W)``). The last three dimensions are treated
+    as the image dimensions.
+
     :param observation_space:
     :param check_channels: Whether to do or not the check for the number of channels.
         e.g., with frame-stacking, the observation space may have more channels than expected.
     :param normalized_image: Whether to assume that the image is already normalized
         or not (this disables dtype and bounds checks): when True, it only checks that
-        the space is a Box and has 3 dimensions.
+        the space is a Box and has at least 3 dimensions.
         Otherwise, it checks that it has expected dtype (uint8) and bounds (values in [0, 255]).
     :return:
     """
     check_dtype = check_bounds = not normalized_image
-    if isinstance(observation_space, spaces.Box) and len(observation_space.shape) == 3:
+    if isinstance(observation_space, spaces.Box) and len(observation_space.shape) >= 3:
         # Check the type
         if check_dtype and observation_space.dtype != np.uint8:
             return False
@@ -58,9 +67,10 @@ def is_image_space(
         # Skip channels check
         if not check_channels:
             return True
-        # Check the number of channels
+        # Check the number of channels using the last 3 dimensions
+        # For frame-stacked spaces (stack, C, H, W), we look at the image part only
         if is_image_space_channels_first(observation_space):
-            n_channels = observation_space.shape[0]
+            n_channels = observation_space.shape[-3]
         else:
             n_channels = observation_space.shape[-1]
         # GrayScale, RGB, RGBD

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -1,7 +1,14 @@
+import numpy as np
+import pytest
 import torch
 from gymnasium import spaces
 
-from stable_baselines3.common.preprocessing import get_obs_shape, preprocess_obs
+from stable_baselines3.common.preprocessing import (
+    get_obs_shape,
+    is_image_space,
+    is_image_space_channels_first,
+    preprocess_obs,
+)
 
 
 def test_get_obs_shape_discrete():
@@ -64,3 +71,104 @@ def test_preprocess_obs_multidimensional_box():
     )
     expected = torch.tensor([[[1.5, 0.3, -1.8], [0.1, -0.6, -1.4]]], dtype=torch.float32)
     torch.testing.assert_close(actual, expected)
+
+
+class TestIsImageSpaceFrameStacked:
+    """Tests for is_image_space with higher-dimensional (frame-stacked) observation spaces.
+
+    Regression tests for https://github.com/DLR-RM/stable-baselines3/issues/2090
+    """
+
+    def test_4d_channel_first(self):
+        """4D channel-first space (stack, C, H, W) should be detected as image."""
+        space = spaces.Box(0, 255, shape=(2, 3, 64, 64), dtype=np.uint8)
+        assert is_image_space(space)
+
+    def test_4d_channel_last(self):
+        """4D channel-last space (stack, H, W, C) should be detected as image."""
+        space = spaces.Box(0, 255, shape=(2, 64, 64, 3), dtype=np.uint8)
+        assert is_image_space(space)
+
+    def test_4d_check_channels_channel_first(self):
+        """check_channels=True should correctly identify channels in 4D channel-first."""
+        space = spaces.Box(0, 255, shape=(2, 3, 64, 64), dtype=np.uint8)
+        assert is_image_space(space, check_channels=True)
+
+    def test_4d_check_channels_channel_last(self):
+        """check_channels=True should correctly identify channels in 4D channel-last."""
+        space = spaces.Box(0, 255, shape=(2, 64, 64, 3), dtype=np.uint8)
+        assert is_image_space(space, check_channels=True)
+
+    def test_4d_odd_channels_rejected(self):
+        """4D space with invalid channel count should fail check_channels."""
+        space = spaces.Box(0, 255, shape=(2, 5, 64, 64), dtype=np.uint8)
+        assert is_image_space(space, check_channels=False)
+        assert not is_image_space(space, check_channels=True)
+
+    def test_4d_normalized_image(self):
+        """4D normalized image (float, [0,1]) should be accepted with normalized_image=True."""
+        space = spaces.Box(0.0, 1.0, shape=(2, 3, 64, 64), dtype=np.float32)
+        assert is_image_space(space, normalized_image=True)
+
+    def test_4d_wrong_dtype_rejected(self):
+        """4D space with float dtype should be rejected without normalized_image."""
+        space = spaces.Box(0, 255, shape=(2, 3, 64, 64), dtype=np.float32)
+        assert not is_image_space(space)
+
+    def test_4d_wrong_bounds_rejected(self):
+        """4D space with incorrect bounds should be rejected."""
+        space = spaces.Box(0, 10, shape=(2, 3, 64, 64), dtype=np.uint8)
+        assert not is_image_space(space)
+
+    def test_5d_space(self):
+        """5D space should also be detected as image (extra batch/stack dims)."""
+        space = spaces.Box(0, 255, shape=(4, 2, 3, 64, 64), dtype=np.uint8)
+        assert is_image_space(space)
+
+    def test_5d_check_channels(self):
+        """5D space should correctly extract channel count from last 3 dims."""
+        space = spaces.Box(0, 255, shape=(4, 2, 3, 64, 64), dtype=np.uint8)
+        assert is_image_space(space, check_channels=True)
+
+    def test_3d_still_works(self):
+        """3D image spaces should continue to work (no regression)."""
+        space = spaces.Box(0, 255, shape=(3, 64, 64), dtype=np.uint8)
+        assert is_image_space(space)
+        assert is_image_space(space, check_channels=True)
+
+    def test_2d_still_rejected(self):
+        """2D spaces should still be rejected."""
+        space = spaces.Box(0, 255, shape=(64, 64), dtype=np.uint8)
+        assert not is_image_space(space)
+
+    def test_1d_still_rejected(self):
+        """1D spaces should still be rejected."""
+        space = spaces.Box(0, 255, shape=(64,), dtype=np.uint8)
+        assert not is_image_space(space)
+
+
+class TestIsImageSpaceChannelsFirstFrameStacked:
+    """Tests for is_image_space_channels_first with higher-dimensional spaces."""
+
+    def test_4d_channel_first(self):
+        """4D channel-first (stack, C, H, W) should return True."""
+        space = spaces.Box(0, 255, shape=(2, 3, 64, 64), dtype=np.uint8)
+        assert is_image_space_channels_first(space)
+
+    def test_4d_channel_last(self):
+        """4D channel-last (stack, H, W, C) should return False."""
+        space = spaces.Box(0, 255, shape=(2, 64, 64, 3), dtype=np.uint8)
+        assert not is_image_space_channels_first(space)
+
+    def test_4d_channel_mid_warns(self):
+        """4D space with ambiguous middle channel should warn."""
+        space = spaces.Box(0, 255, shape=(2, 64, 3, 64), dtype=np.uint8)
+        with pytest.warns(Warning):
+            assert not is_image_space_channels_first(space)
+
+    def test_3d_still_works(self):
+        """3D spaces should still work correctly (no regression)."""
+        space_cf = spaces.Box(0, 255, shape=(3, 64, 64), dtype=np.uint8)
+        assert is_image_space_channels_first(space_cf)
+        space_cl = spaces.Box(0, 255, shape=(64, 64, 3), dtype=np.uint8)
+        assert not is_image_space_channels_first(space_cl)


### PR DESCRIPTION
## Summary

Fixes #2090 — `is_image_space()` now correctly recognizes frame-stacked observation spaces (ndim >= 3) as image spaces.

**Disclosure**: This PR was developed with the assistance of Claude (LLM), as required by the contribution guidelines.

### Changes
- `is_image_space()`: Changed dimension check from `== 3` to `>= 3` to support 4D+ frame-stacked spaces
- `is_image_space_channels_first()`: Use last 3 dimensions (`shape[-3:]`) for channel position heuristic, so frame-stack dims don't interfere
- Channel count extraction: Use `shape[-3]` (channels-first) or `shape[-1]` (channels-last) instead of `shape[0]`/`shape[-1]`

<details>
<summary>Before</summary>

```
3D image space (3, 64, 64): True
4D frame-stacked space shape: (2, 3, 64, 64)
4D frame-stacked is_image_space: False     ← BUG
3D channel-last space (64, 64, 3): True
4D channel-last frame-stacked shape: (2, 64, 64, 3)
4D channel-last frame-stacked is_image_space: False     ← BUG
```

</details>

<details>
<summary>After</summary>

```
3D image space (3, 64, 64): True
4D frame-stacked space shape: (2, 3, 64, 64)
4D frame-stacked is_image_space: True      ← FIXED
3D channel-last space (64, 64, 3): True
4D channel-last frame-stacked shape: (2, 64, 64, 3)
4D channel-last frame-stacked is_image_space: True      ← FIXED
```

</details>

<details>
<summary>Test results (29 passed)</summary>

```
tests/test_preprocessing.py::TestIsImageSpaceFrameStacked (13 tests) PASSED
tests/test_preprocessing.py::TestIsImageSpaceChannelsFirstFrameStacked (4 tests) PASSED
======================== 29 passed in 2.08s ========================
```

</details>

## Test plan
- [x] 17 new tests covering 4D/5D spaces, channel-first/last, check_channels, normalized_image, wrong dtype/bounds, and regression for 3D/2D/1D
- [x] All 29 preprocessing tests pass (12 existing + 17 new)
- [x] `test_cnn.py::test_image_space_checks` passes (no regression)