### PR TITLE
Refactor buffer samples from NamedTuple to dataclass

### DIFF
--- a/stable_baselines3/common/type_aliases.py
+++ b/stable_baselines3/common/type_aliases.py
@@ -1,6 +1,7 @@
 """Common aliases for type hints"""
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass, fields
 from enum import Enum
 from typing import TYPE_CHECKING, Any, NamedTuple, Protocol, SupportsFloat, Union
 
@@ -29,7 +30,18 @@ PyTorchObs = Union[th.Tensor, TensorDict]  # noqa: UP007
 Schedule = Callable[[float], float]
 
 
-class RolloutBufferSamples(NamedTuple):
+class _DataclassSamplesMixin:
+    """Mixin to maintain backward compatibility with NamedTuple iteration."""
+
+    def __iter__(self) -> Iterator:
+        return (getattr(self, f.name) for f in fields(self))
+
+    def __getitem__(self, index: int) -> Any:
+        return list(self)[index]
+
+
+@dataclass
+class RolloutBufferSamples(_DataclassSamplesMixin):
     observations: th.Tensor
     actions: th.Tensor
     old_values: th.Tensor
@@ -38,7 +50,8 @@ class RolloutBufferSamples(NamedTuple):
     returns: th.Tensor
 
 
-class DictRolloutBufferSamples(NamedTuple):
+@dataclass
+class DictRolloutBufferSamples(_DataclassSamplesMixin):
     observations: TensorDict
     actions: th.Tensor
     old_values: th.Tensor
@@ -47,7 +60,8 @@ class DictRolloutBufferSamples(NamedTuple):
     returns: th.Tensor
 
 
-class ReplayBufferSamples(NamedTuple):
+@dataclass
+class ReplayBufferSamples(_DataclassSamplesMixin):
     observations: th.Tensor
     actions: th.Tensor
     next_observations: th.Tensor
@@ -57,7 +71,8 @@ class ReplayBufferSamples(NamedTuple):
     discounts: th.Tensor | None = None
 
 
-class DictReplayBufferSamples(NamedTuple):
+@dataclass
+class DictReplayBufferSamples(_DataclassSamplesMixin):
     observations: TensorDict
     actions: th.Tensor
     next_observations: TensorDict

--- a/tests/test_buffers.py
+++ b/tests/test_buffers.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass
+
 import gymnasium as gym
 import numpy as np
 import pytest
@@ -8,7 +10,12 @@ from stable_baselines3 import A2C
 from stable_baselines3.common.buffers import DictReplayBuffer, DictRolloutBuffer, ReplayBuffer, RolloutBuffer
 from stable_baselines3.common.env_checker import check_env
 from stable_baselines3.common.env_util import make_vec_env
-from stable_baselines3.common.type_aliases import DictReplayBufferSamples, ReplayBufferSamples
+from stable_baselines3.common.type_aliases import (
+    DictReplayBufferSamples,
+    DictRolloutBufferSamples,
+    ReplayBufferSamples,
+    RolloutBufferSamples,
+)
 from stable_baselines3.common.utils import get_device
 from stable_baselines3.common.vec_env import VecNormalize
 
@@ -243,3 +250,107 @@ def test_custom_rollout_buffer():
 
     with pytest.raises(AssertionError, match=r"DictRolloutBuffer must be used with Dict obs space only"):
         A2C("MlpPolicy", "Pendulum-v1", rollout_buffer_class=DictRolloutBuffer)
+
+
+class TestDataclassSamples:
+    """Tests for dataclass-based buffer samples (issue #2202)."""
+
+    def test_subclassing_replay_buffer_samples(self):
+        """Subclassing ReplayBufferSamples should work (main motivation for #2202)."""
+
+        @dataclass
+        class CustomReplayBufferSamples(ReplayBufferSamples):
+            extra_field: th.Tensor = None
+
+        sample = CustomReplayBufferSamples(
+            observations=th.zeros(2, 3),
+            actions=th.zeros(2, 1),
+            next_observations=th.zeros(2, 3),
+            dones=th.zeros(2, 1),
+            rewards=th.zeros(2, 1),
+            extra_field=th.ones(2, 1),
+        )
+        assert sample.extra_field is not None
+        assert th.equal(sample.extra_field, th.ones(2, 1))
+
+    def test_subclassing_rollout_buffer_samples(self):
+        """Subclassing RolloutBufferSamples should work."""
+
+        @dataclass
+        class CustomRolloutBufferSamples(RolloutBufferSamples):
+            auxiliary_loss: th.Tensor = None
+
+        sample = CustomRolloutBufferSamples(
+            observations=th.zeros(2, 3),
+            actions=th.zeros(2, 1),
+            old_values=th.zeros(2),
+            old_log_prob=th.zeros(2),
+            advantages=th.zeros(2),
+            returns=th.zeros(2),
+            auxiliary_loss=th.ones(2),
+        )
+        assert th.equal(sample.auxiliary_loss, th.ones(2))
+
+    def test_positional_construction(self):
+        """Positional arg construction should still work (backward compat)."""
+        sample = ReplayBufferSamples(
+            th.zeros(2, 3),
+            th.zeros(2, 1),
+            th.zeros(2, 3),
+            th.zeros(2, 1),
+            th.zeros(2, 1),
+        )
+        assert sample.discounts is None
+        assert sample.observations.shape == (2, 3)
+
+    def test_iteration_backward_compat(self):
+        """Iteration over fields should work like NamedTuple."""
+        sample = RolloutBufferSamples(
+            observations=th.zeros(2, 3),
+            actions=th.zeros(2, 1),
+            old_values=th.zeros(2),
+            old_log_prob=th.zeros(2),
+            advantages=th.zeros(2),
+            returns=th.zeros(2),
+        )
+        values = list(sample)
+        assert len(values) == 6
+        assert th.equal(values[0], th.zeros(2, 3))
+
+    def test_dict_replay_buffer_samples_subclass(self):
+        """DictReplayBufferSamples should be subclassable."""
+
+        @dataclass
+        class CustomDictReplayBufferSamples(DictReplayBufferSamples):
+            priorities: th.Tensor = None
+
+        sample = CustomDictReplayBufferSamples(
+            observations={"obs": th.zeros(2, 3)},
+            actions=th.zeros(2, 1),
+            next_observations={"obs": th.zeros(2, 3)},
+            dones=th.zeros(2, 1),
+            rewards=th.zeros(2, 1),
+            priorities=th.ones(2),
+        )
+        assert th.equal(sample.priorities, th.ones(2))
+
+    def test_default_discounts(self):
+        """ReplayBufferSamples.discounts should default to None."""
+        sample = ReplayBufferSamples(
+            observations=th.zeros(2, 3),
+            actions=th.zeros(2, 1),
+            next_observations=th.zeros(2, 3),
+            dones=th.zeros(2, 1),
+            rewards=th.zeros(2, 1),
+        )
+        assert sample.discounts is None
+
+        sample_with_discounts = ReplayBufferSamples(
+            observations=th.zeros(2, 3),
+            actions=th.zeros(2, 1),
+            next_observations=th.zeros(2, 3),
+            dones=th.zeros(2, 1),
+            rewards=th.zeros(2, 1),
+            discounts=th.ones(2, 1),
+        )
+        assert th.equal(sample_with_discounts.discounts, th.ones(2, 1))


### PR DESCRIPTION
## Summary

Closes #2202 — Converts `ReplayBufferSamples`, `RolloutBufferSamples`, `DictReplayBufferSamples`, and `DictRolloutBufferSamples` from `NamedTuple` to `@dataclass` to enable subclassing.

**Disclosure**: This PR was developed with the assistance of Claude (LLM), as required by the contribution guidelines.

### Changes
- `type_aliases.py`: Replace `NamedTuple` with `@dataclass` for the 4 `*Samples` classes
- Added `_DataclassSamplesMixin` with `__iter__` and `__getitem__` for backward compatibility (existing code that iterates over sample fields continues to work)
- `RolloutReturn` and `TrainFreq` are **not changed** (out of scope)

### Backward compatibility
- Positional construction: `ReplayBufferSamples(*tuple(map(...)))` ✅
- Keyword construction: `DictReplayBufferSamples(observations=..., ...)` ✅
- Attribute access: `samples.observations` ✅
- Iteration: `for value in samples` ✅ (via mixin)
- Default values: `discounts: th.Tensor | None = None` ✅
- **New**: Subclassing now works (the main motivation for #2202)

<details>
<summary>Before (subclassing fails)</summary>

```python
class CustomReplayBufferSamples(ReplayBufferSamples):
    extra_field: th.Tensor  # TypeError with NamedTuple
```

</details>

<details>
<summary>After (subclassing works)</summary>

```python
@dataclass
class CustomReplayBufferSamples(ReplayBufferSamples):
    extra_field: th.Tensor = None  # Works with dataclass

sample = CustomReplayBufferSamples(
    observations=th.zeros(2, 3), actions=th.zeros(2, 1),
    next_observations=th.zeros(2, 3), dones=th.zeros(2, 1),
    rewards=th.zeros(2, 1), extra_field=th.ones(2, 1),
)
assert sample.extra_field is not None  # ✅
```

</details>

<details>
<summary>Test results (85 passed, 4 skipped)</summary>

```
tests/test_buffers.py (79 existing + 6 new tests)
TestDataclassSamples::test_subclassing_replay_buffer_samples PASSED
TestDataclassSamples::test_subclassing_rollout_buffer_samples PASSED
TestDataclassSamples::test_positional_construction PASSED
TestDataclassSamples::test_iteration_backward_compat PASSED
TestDataclassSamples::test_dict_replay_buffer_samples_subclass PASSED
TestDataclassSamples::test_default_discounts PASSED
======================== 85 passed, 4 skipped in 2.82s =========================
```

</details>

## Test plan
- [x] 6 new tests covering subclassing, positional construction, iteration, and default values
- [x] All 79 existing buffer tests pass (no regression)
- [x] Note: SB3 contrib will need a matching PR (as mentioned by @araffin in #2202)