### PR TITLE
Fix Taxi-v3 deprecation in tests (gymnasium 1.3.0 compatibility)

### DIFF
--- a/docs/misc/changelog.md
+++ b/docs/misc/changelog.md
@@ -12,6 +12,7 @@
 ### New Features:
 
 ### Bug Fixes:
+- Fixed deprecated error Taxi-v3 from gymnasium v1.3.0 in tests
 
 ### [SB3-Contrib]
 
@@ -20,7 +21,6 @@
 ### [SBX] (SB3 + Jax)
 
 ### Deprecations:
-- Fixed deprecated Taxi-v3 from gymnasium 1.3.0
 
 ### Others:
 

--- a/docs/misc/changelog.md
+++ b/docs/misc/changelog.md
@@ -20,6 +20,7 @@
 ### [SBX] (SB3 + Jax)
 
 ### Deprecations:
+- Fixed deprecated Taxi-v3 from gymnasium 1.3.0
 
 ### Others:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,17 +39,18 @@ exclude = """(?x)(
 env = ["PYTHONHASHSEED=0"]
 
 filterwarnings = [
+    # multiprocessing and fork method
+    "ignore:This process.*is multi-threaded, use of fork\\(\\).*may lead to deadlocks:DeprecationWarning:multiprocessing.popen_fork.py",
     # A2C/PPO on GPU
     "ignore:You are trying to run (PPO|A2C) on the GPU",
     # Tensorboard warnings
     "ignore::DeprecationWarning:tensorboard",
     # Gymnasium warnings
     "ignore::UserWarning:gymnasium",
+    # Taxi-v3 and CliffWalking-v0
+    "ignore::DeprecationWarning:gymnasium.envs.registration",
     # tqdm warning about rich being experimental
     "ignore:rich is experimental",
-    # Pygame warnings about pkg_resources
-    "ignore:pkg_resources is deprecated",
-    "ignore:Deprecated call to `pkg_resources",
 ]
 markers = [
     "expensive: marks tests as expensive (deselect with '-m \"not expensive\"')",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,8 @@ exclude = """(?x)(
 env = ["PYTHONHASHSEED=0"]
 
 filterwarnings = [
-    # multiprocessing and fork method
-    "ignore:This process.*is multi-threaded, use of fork\\(\\).*may lead to deadlocks:DeprecationWarning:multiprocessing.popen_fork.py",
+    # multiprocessing and fork method, use of fork may lead to deadlocks
+    "ignore::DeprecationWarning:multiprocessing.popen_fork",
     # A2C/PPO on GPU
     "ignore:You are trying to run (PPO|A2C) on the GPU",
     # Tensorboard warnings

--- a/stable_baselines3/common/logger.py
+++ b/stable_baselines3/common/logger.py
@@ -428,6 +428,7 @@ class TensorBoardOutputFormat(KVWriter):
                 self.writer.add_image(key, value.image, step, dataformats=value.dataformats)
 
             if isinstance(value, HParam):
+                assert self.writer.file_writer is not None
                 # we don't use `self.writer.add_hparams` to have control over the log_dir
                 experiment, session_start_info, session_end_info = hparams(value.hparam_dict, metric_dict=value.metric_dict)
                 self.writer.file_writer.add_summary(experiment)

--- a/tests/test_cnn.py
+++ b/tests/test_cnn.py
@@ -133,12 +133,19 @@ def test_features_extractor_target_net(model_class, share_features_extractor):
     if model_class == DQN and share_features_extractor:
         pytest.skip()
 
-    env = FakeImageEnv(screen_height=40, screen_width=40, n_channels=1, discrete=model_class not in {SAC, TD3})
+    env = FakeImageEnv(screen_height=36, screen_width=36, n_channels=1, discrete=model_class not in {SAC, TD3})
     # Avoid memory error when using replay buffer
     # Reduce the size of the features
-    kwargs = dict(buffer_size=250, learning_starts=100, policy_kwargs=dict(features_extractor_kwargs=dict(features_dim=32)))
+    kwargs = dict(
+        buffer_size=100,
+        learning_starts=50,
+        policy_kwargs=dict(features_extractor_kwargs=dict(features_dim=8)),
+        learning_rate=1e-3,
+    )
     if model_class != DQN:
         kwargs["policy_kwargs"]["share_features_extractor"] = share_features_extractor
+    else:
+        kwargs["target_update_interval"] = 10
 
     # No delay for TD3 (changes when the actor and polyak update take place)
     if model_class == TD3:
@@ -172,7 +179,7 @@ def test_features_extractor_target_net(model_class, share_features_extractor):
     if model_class == TD3:
         params_should_match(model.actor.parameters(), model.actor_target.parameters())
 
-    model.learn(200)
+    model.learn(100)
 
     # Critic and target should differ
     params_should_differ(model.critic.parameters(), model.critic_target.parameters())

--- a/tests/test_spaces.py
+++ b/tests/test_spaces.py
@@ -123,7 +123,8 @@ def test_sde_multi_dim():
 @pytest.mark.parametrize("model_class", [A2C, PPO, DQN])
 @pytest.mark.parametrize("env", ["Taxi-v3"])
 def test_discrete_obs_space(model_class, env):
-    env = make_vec_env(env, n_envs=2, seed=0)
+
+    env = _make_env_safe(env, n_envs=2, seed=0)
     kwargs = {}
     if model_class == DQN:
         kwargs = dict(buffer_size=1000, learning_starts=100)
@@ -173,3 +174,17 @@ def test_multidim_binary_not_supported():
     env = DummyEnv(BOX_SPACE_FLOAT32, spaces.MultiBinary([2, 3]))
     with pytest.raises(AssertionError, match=r"Multi-dimensional MultiBinary\(.*\) action space is not supported"):
         A2C("MlpPolicy", env)
+
+
+def _make_env_safe(env_id, **kwargs):
+    try:
+        return make_vec_env(env_id, **kwargs)
+    except gym.error.DeprecatedEnv:
+        # map deprecated to new (better extendability for this)
+        fallback_map = {
+            # as of gymnasium 1.3.0 Taxi-v3 is deprecated
+            "Taxi-v3": "Taxi-v4",
+        }
+        if env_id in fallback_map:
+            return make_vec_env(fallback_map[env_id], **kwargs)
+        raise


### PR DESCRIPTION


## Description

Created function `_make_env_safe(env_id, **kwargs)` to check if there exists a `gym.error.DeprecatedEnv`. If said exception exists it checks the fallback hash map and if the env_id exists in the hash map then it uses that version else it raises an exception.

## Motivation and Context

It fixes the error `gymnasium.error.DeprecatedEnv: Environment version v3 for 'Taxi' is deprecated. Please use 'Taxi-v4' instead.` 

In the test file `test_spaces.py`: 

Specifically `tests/test_spaces.py::test_discrete_obs_space`


closes https://github.com/DLR-RM/stable-baselines3/issues/2246

- [x] I have raised an issue to propose this change ([required](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) for new features and bug fixes)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the changelog accordingly (`docs/misc/changelog.md`) (**required**).
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary)
- [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary)
- [x] I have reformatted the code using `make format` (**required**)
- [x] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [x] I have ensured `make pytest` and `make type` both pass. (**required**)
- [x] I have checked that the documentation builds using `make doc` (**required**)


