### PR TITLE
fix: update HTTP URLs to HTTPS across docs and source files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ https://github.com/DLR-RM/stable-baselines3
 Note: If you do not follow the template (and its mandatory steps), your pull request will be ignored.
 
 If you are not familiar with creating a Pull Request, here are some guides:
-- http://stackoverflow.com/questions/14680711/how-to-do-a-github-pull-request
+- https://stackoverflow.com/questions/14680711/how-to-do-a-github-pull-request
 - https://help.github.com/articles/creating-a-pull-request/
 
 

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ To cite this repository in publications:
   volume  = {22},
   number  = {268},
   pages   = {1-8},
-  url     = {http://jmlr.org/papers/v22/20-1364.html}
+  url     = {https://jmlr.org/papers/v22/20-1364.html}
 }
 ```
 
@@ -279,7 +279,7 @@ If you want to contribute, please read [**CONTRIBUTING.md**](./CONTRIBUTING.md) 
 
 The initial work to develop Stable Baselines3 was partially funded by the project *Reduced Complexity Models* from the *Helmholtz-Gemeinschaft Deutscher Forschungszentren*, and by the EU Horizon 2020 Research and Innovation Programme under grant number 951992 ([VeriDream](https://www.veridream.eu/)).
 
-The original version, Stable Baselines, was created in the [robotics lab U2IS](http://u2is.ensta-paristech.fr/index.php?lang=en) ([INRIA Flowers](https://flowers.inria.fr/) team) at [ENSTA ParisTech](http://www.ensta-paristech.fr/en).
+The original version, Stable Baselines, was created in the [robotics lab U2IS](https://u2is.ensta-paristech.fr/index.php?lang=en) ([INRIA Flowers](https://flowers.inria.fr/) team) at [ENSTA ParisTech](https://www.ensta-paristech.fr/en).
 
 
 Logo credits: [L.M. Tenkes](https://www.instagram.com/lucillehue/)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,7 +3,7 @@
 #
 # This file does only contain a selection of the most common options. For a
 # full list see the documentation:
-# http://www.sphinx-doc.org/en/master/config
+# https://www.sphinx-doc.org/en/master/config
 
 # -- Path setup --------------------------------------------------------------
 

--- a/docs/guide/examples.md
+++ b/docs/guide/examples.md
@@ -639,7 +639,7 @@ Policies also offers a simple way to save/load weights as a NumPy vector, using 
 and `load_from_vector()` method.
 
 Following example demonstrates reading parameters, modifying some of them and loading them to model
-by implementing [evolution strategy (es)](http://blog.otoro.net/2017/10/29/visual-evolution-strategies/)
+by implementing [evolution strategy (es)](https://blog.otoro.net/2017/10/29/visual-evolution-strategies/)
 for solving the `CartPole-v1` environment. The initial guess for parameters is obtained by running
 A2C policy gradient updates on the model.
 

--- a/docs/guide/rl.md
+++ b/docs/guide/rl.md
@@ -13,6 +13,6 @@ However, if you want to learn about RL, there are several good resources to get 
 - [RL103: From Deep Q-Learning (DQN) to Soft Actor-Critic (SAC) and Beyond](https://araffin.github.io/post/rl103/)
 - [Lilian Weng's blog](https://lilianweng.github.io/lil-log/2018/04/08/policy-gradient-algorithms.html)
 - [Berkeley's Deep RL Bootcamp](https://sites.google.com/view/deep-rl-bootcamp/lectures)
-- [Berkeley's Deep Reinforcement Learning course](http://rail.eecs.berkeley.edu/deeprlcourse/)
+- [Berkeley's Deep Reinforcement Learning course](https://rail.eecs.berkeley.edu/deeprlcourse/)
 - [Decisions & Dragons - FAQ for RL foundations](https://www.decisionsanddragons.com)
 - [More resources](https://github.com/dennybritz/reinforcement-learning)

--- a/docs/guide/rl_tips.md
+++ b/docs/guide/rl_tips.md
@@ -57,7 +57,7 @@ For instance, in this [work](https://www.youtube.com/watch?v=aTDkYFZFWug) by ETH
 As general advice, to obtain better performance, you should increase the budget of the agent (number of training timesteps).
 
 In order to achieve the desired behavior, expert knowledge is often required to design an adequate reward function.
-This *reward engineering* (or *RewArt* as coined by [Freek Stulp](http://www.freekstulp.net/)), necessitates several iterations. As a good example of reward shaping,
+This *reward engineering* (or *RewArt* as coined by [Freek Stulp](https://www.freekstulp.net/)), necessitates several iterations. As a good example of reward shaping,
 you can take a look at [Deep Mimic paper](https://xbpeng.github.io/projects/DeepMimic/index.html) which combines imitation learning and reinforcement learning to do acrobatic moves.
 
 A final limitation of RL is the instability of training. That is, you can observe a huge drop in performance during training.
@@ -222,7 +222,7 @@ We have a [video on YouTube about reliable RL](https://www.youtube.com/watch?v=7
 this section in more details. You can also find the [slides online](https://araffin.github.io/slides/tips-reliable-rl/).
 :::
 
-When you try to reproduce a RL paper by implementing the algorithm, the [nuts and bolts of RL research](http://joschu.net/docs/nuts-and-bolts.pdf)
+When you try to reproduce a RL paper by implementing the algorithm, the [nuts and bolts of RL research](https://joschu.net/docs/nuts-and-bolts.pdf)
 by John Schulman are quite useful ([video](https://www.youtube.com/watch?v=8EcdaCk9KaQ)).
 
 We *recommend following those steps to have a working RL algorithm*:

--- a/docs/modules/ddpg.md
+++ b/docs/modules/ddpg.md
@@ -31,7 +31,7 @@ they share the same policies and same implementation.
 
 ## Notes
 
-- Deterministic Policy Gradient: <http://proceedings.mlr.press/v32/silver14.pdf>
+- Deterministic Policy Gradient: <https://proceedings.mlr.press/v32/silver14.pdf>
 - DDPG Paper: <https://arxiv.org/abs/1509.02971>
 - OpenAI Spinning Guide for DDPG: <https://spinningup.openai.com/en/latest/algorithms/ddpg.html>
 

--- a/docs/modules/dqn.md
+++ b/docs/modules/dqn.md
@@ -7,7 +7,7 @@
 
 # DQN
 
-[Deep Q Network (DQN)](https://arxiv.org/abs/1312.5602) builds on [Fitted Q-Iteration (FQI)](http://ml.informatik.uni-freiburg.de/former/_media/publications/rieecml05.pdf)
+[Deep Q Network (DQN)](https://arxiv.org/abs/1312.5602) builds on [Fitted Q-Iteration (FQI)](https://ml.informatik.uni-freiburg.de/former/_media/publications/rieecml05.pdf)
 and make use of different tricks to stabilize the learning with neural networks: it uses a replay buffer, a target network and gradient clipping.
 
 ```{eval-rst}

--- a/stable_baselines3/common/noise.py
+++ b/stable_baselines3/common/noise.py
@@ -51,7 +51,7 @@ class OrnsteinUhlenbeckActionNoise(ActionNoise):
     """
     An Ornstein Uhlenbeck action noise, this is designed to approximate Brownian motion with friction.
 
-    Based on http://math.stackexchange.com/questions/1287634/implementing-ornstein-uhlenbeck-in-matlab
+    Based on https://math.stackexchange.com/questions/1287634/implementing-ornstein-uhlenbeck-in-matlab
 
     :param mean: Mean of the noise
     :param sigma: Scale of the noise

--- a/stable_baselines3/common/sb2_compat/rmsprop_tf_like.py
+++ b/stable_baselines3/common/sb2_compat/rmsprop_tf_like.py
@@ -20,7 +20,7 @@ class RMSpropTFLike(Optimizer):
         - Initialize squared gradient to ones rather than zeros
 
     Proposed by G. Hinton in his
-    `course <http://www.cs.toronto.edu/~tijmen/csc321/slides/lecture_slides_lec6.pdf>`_.
+    `course <https://www.cs.toronto.edu/~tijmen/csc321/slides/lecture_slides_lec6.pdf>`_.
 
     The centered version first appears in `Generating Sequences
     With Recurrent Neural Networks <https://arxiv.org/pdf/1308.0850v5.pdf>`_.

--- a/stable_baselines3/ddpg/ddpg.py
+++ b/stable_baselines3/ddpg/ddpg.py
@@ -15,7 +15,7 @@ class DDPG(TD3):
     """
     Deep Deterministic Policy Gradient (DDPG).
 
-    Deterministic Policy Gradient: http://proceedings.mlr.press/v32/silver14.pdf
+    Deterministic Policy Gradient: https://proceedings.mlr.press/v32/silver14.pdf
     DDPG Paper: https://arxiv.org/abs/1509.02971
     Introduction to DDPG: https://spinningup.openai.com/en/latest/algorithms/ddpg.html
 

--- a/stable_baselines3/ppo/ppo.py
+++ b/stable_baselines3/ppo/ppo.py
@@ -258,7 +258,7 @@ class PPO(OnPolicyAlgorithm):
                 # Calculate approximate form of reverse KL Divergence for early stopping
                 # see issue #417: https://github.com/DLR-RM/stable-baselines3/issues/417
                 # and discussion in PR #419: https://github.com/DLR-RM/stable-baselines3/pull/419
-                # and Schulman blog: http://joschu.net/blog/kl-approx.html
+                # and Schulman blog: https://joschu.net/blog/kl-approx.html
                 with th.no_grad():
                     log_ratio = log_prob - rollout_data.old_log_prob
                     approx_kl_div = th.mean((th.exp(log_ratio) - 1) - log_ratio).cpu().numpy()


### PR DESCRIPTION
## Description

Update insecure HTTP links to HTTPS across documentation, docstrings, and README where the target server supports HTTPS.

### Changes
- : StackOverflow link
- : JMLR, ENSTA ParisTech, robotics lab links
- : Sphinx docs link
- , : Paper links
- , , : Course and blog links
- , , , : Docstring URLs

All target servers have been verified to support HTTPS.