### PR TITLE
Render initial state in evaluate_policy (Fixes #1692)

### DIFF
--- a/docs/misc/changelog.md
+++ b/docs/misc/changelog.md
@@ -13,6 +13,7 @@
 
 ### Bug Fixes:
 - Fixed deprecated error Taxi-v3 from gymnasium v1.3.0 in tests
+- Fixed `evaluate_policy()` not rendering the initial state of each episode when `render=True` (used by `EvalCallback`); the last (post-terminal) frame is still not rendered because `VecEnv` resets sub-environments automatically (documented in the docstring) (@midhunxavier)
 
 ### [SB3-Contrib]
 
@@ -1864,7 +1865,7 @@ And all the contributors:
 @lutogniew @lbergmann1 @lukashass @BertrandDecoster @pseudo-rnd-thoughts @stefanbschneider @kyle-he @PatrickHelm @corentinlger
 @marekm4 @stagoverflow @rushitnshah @markscsmith @NickLucche @cschindlbeck @peteole @jak3122 @will-maclean
 @brn-dev @jmacglashan @kplers @MarcDcls @chrisgao99 @pstahlhofen @akanto @Trenza1ore @JonathanColetti @unexploredtest
-@m-abr
+@m-abr @midhunxavier
 
 [@adamgleave]: https://github.com/adamgleave
 [@araffin]: https://github.com/araffin

--- a/stable_baselines3/common/evaluation.py
+++ b/stable_baselines3/common/evaluation.py
@@ -42,7 +42,9 @@ def evaluate_policy(
     :param env: The gym environment or ``VecEnv`` environment.
     :param n_eval_episodes: Number of episode to evaluate the agent
     :param deterministic: Whether to use deterministic or stochastic actions
-    :param render: Whether to render the environment or not
+    :param render: Whether to render the environment or not.
+        The initial state of each episode is rendered, but the last (post-terminal)
+        frame is not, because ``VecEnv`` resets sub-environments automatically.
     :param callback: callback function to perform additional checks,
         called ``n_envs`` times after each step.
         Gets locals() and globals() passed as parameters.
@@ -88,6 +90,15 @@ def evaluate_policy(
     observations = env.reset()
     states = None
     episode_starts = np.ones((env.num_envs,), dtype=bool)
+
+    if render:
+        # Render the initial state (after reset, before the first action).
+        # Note: because ``VecEnv`` automatically resets sub-environments when an
+        # episode ends, the very last (post-terminal) frame of each episode is not
+        # rendered. If you need to render that final frame, wrap your ``gym.Env``
+        # with a custom wrapper that calls ``render()`` inside ``step()``.
+        env.render()
+
     while (episode_counts < episode_count_targets).any():
         actions, states = model.predict(
             observations,  # type: ignore[arg-type]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -285,6 +285,53 @@ def test_evaluate_vector_env(n_envs):
     assert count_callback.count == n_eval_episodes
 
 
+def test_evaluate_policy_renders_initial_state():
+    # Regression test for https://github.com/DLR-RM/stable-baselines3/issues/1692
+    # ``evaluate_policy`` must render the initial state of each episode
+    # (after reset, before the first action) so that environments with
+    # dynamic/random initial states are rendered correctly.
+    events: list[str] = []
+
+    class RecordingEnv(gym.Env):
+        metadata = {"render_modes": ["human"]}
+
+        def __init__(self):
+            self.observation_space = spaces.Box(-1.0, 1.0, (1,), dtype=np.float32)
+            self.action_space = spaces.Discrete(2)
+            self.render_mode = "human"
+            self.step_count = 0
+
+        def reset(self, *, seed=None, options=None):
+            self.step_count = 0
+            events.append("reset")
+            return np.zeros(1, dtype=np.float32), {}
+
+        def step(self, action):
+            self.step_count += 1
+            events.append("step")
+            terminated = self.step_count >= 3
+            return np.zeros(1, dtype=np.float32), 0.0, terminated, False, {}
+
+        def render(self):
+            events.append("render")
+
+    class DummyModel:
+        def predict(self, observation, state=None, episode_start=None, deterministic=True):
+            events.append("predict")
+            return np.array([0]), None
+
+    env = DummyVecEnv([lambda: RecordingEnv()])
+    evaluate_policy(DummyModel(), env, n_eval_episodes=1, render=True, warn=False)
+
+    # The very first render must happen after the reset but before the first predict,
+    # i.e. the initial state is rendered. On the old (buggy) behavior, render was only
+    # called after the first step, so the first event after reset was "predict".
+    first_render = events.index("render")
+    first_predict = events.index("predict")
+    assert first_render < first_predict, f"Initial state not rendered before first predict: {events}"
+    assert events[:2] == ["reset", "render"], f"Expected initial state to be rendered right after reset: {events}"
+
+
 @pytest.mark.parametrize("vec_env_class", [None, DummyVecEnv, SubprocVecEnv])
 def test_evaluate_policy_monitors(vec_env_class):
     # Make numpy warnings throw exception


### PR DESCRIPTION
## Description

`evaluate_policy()` (used by `EvalCallback`) only called `env.render()` *after*
`env.step()`, so the initial post-reset state of each episode was never rendered.
This adds a single `env.render()` after `env.reset()`, before the first
`predict()`, so the initial state is shown. The final (post-terminal) frame is
intentionally still not rendered because `VecEnv` auto-resets sub-environments;
this caveat is now documented in the `render` docstring with a workaround.

This implements the minimal approach @araffin proposed in the issue thread (render
before predict + document the final-frame limitation), not the rejected
`VecEnv`-subclass approach.

## Motivation and Context

closes #1692

- [x] I have raised an issue to propose this change (required for new features and bug fixes)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

- [x] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the changelog accordingly (`docs/misc/changelog.md`) (**required**).
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
- [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary)
- [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary)
- [x] I have reformatted the code using `make format` (**required**)
- [x] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [x] I have ensured `make pytest` and `make type` both pass. (**required**)
- [x] I have checked that the documentation builds using `make doc` (**required**)

---

**AI-assistance disclosure (per CONTRIBUTING.md):** this change was developed with
the assistance of an LLM (Claude). The approach was proposed by the maintainer
(@araffin) in #1692; I have reviewed and own the change.
