### PR TITLE
docs: warn against using Gymnasium FrameStackObservation for image observations

### DIFF
--- a/docs/guide/custom_env.md
+++ b/docs/guide/custom_env.md
@@ -20,6 +20,15 @@ Although SB3 supports both channel-last and channel-first images as input, we re
 Under the hood, when a channel-last image is passed, SB3 uses a `VecTransposeImage` wrapper to re-order the channels.
 :::
 
+:::{warning}
+Do not use Gymnasium's `FrameStackObservation` wrapper to stack image frames for SB3.
+It adds a new leading dimension (e.g. an image of shape `(3, 64, 64)` becomes `(2, 3, 64, 64)` when stacking 2 frames),
+which SB3's `is_image_space` check treats as a non-image (a batch of images) rather than an image.
+As a consequence, a `FlattenExtractor` is used instead of a CNN, and the CNN policy is silently not applied.
+Use SB3's `VecFrameStack` instead, which stacks frames along the channel dimension and keeps the observation
+recognized as an image (see [issue #2090](https://github.com/DLR-RM/stable-baselines3/issues/2090)).
+:::
+
 :::{note}
 SB3 doesn't support `Discrete` and `MultiDiscrete` spaces with `start!=0`. However, you can update your environment or use a wrapper to make your env compatible with SB3:
 

--- a/docs/misc/changelog.md
+++ b/docs/misc/changelog.md
@@ -32,6 +32,7 @@
 
 - Added example for using torch.compile
 - Fixed many broken links and updated links to https whenever possible
+- Added a warning about using Gymnasium's `FrameStackObservation` with image observations (use `VecFrameStack` instead) (@midhunxavier)
 
 ## Release 2.8.0 (2026-04-01)
 
@@ -1864,7 +1865,7 @@ And all the contributors:
 @lutogniew @lbergmann1 @lukashass @BertrandDecoster @pseudo-rnd-thoughts @stefanbschneider @kyle-he @PatrickHelm @corentinlger
 @marekm4 @stagoverflow @rushitnshah @markscsmith @NickLucche @cschindlbeck @peteole @jak3122 @will-maclean
 @brn-dev @jmacglashan @kplers @MarcDcls @chrisgao99 @pstahlhofen @akanto @Trenza1ore @JonathanColetti @unexploredtest
-@m-abr
+@m-abr @midhunxavier
 
 [@adamgleave]: https://github.com/adamgleave
 [@araffin]: https://github.com/araffin


### PR DESCRIPTION
## Description

Adds a warning to the custom-environment documentation explaining that Gymnasium's `FrameStackObservation` wrapper adds a new **leading** dimension to image observations (e.g. an image of shape `(3, 64, 64)` becomes `(2, 3, 64, 64)` when stacking 2 frames). SB3's `is_image_space` check requires exactly 3 dimensions, so the stacked space is treated as a *batch of images* rather than an image. As a result, a `FlattenExtractor` is silently used instead of a CNN.

The note recommends using SB3's `VecFrameStack` instead (which stacks along the channel dimension and keeps the observation recognized as an image) and links to the issue. A changelog entry is added accordingly.

This follows @araffin's guidance in the issue to keep the `is_image_space` check as-is and document the pitfall instead of changing the behavior.

## Motivation and Context

`closes #2090`

Users stacking image frames with Gymnasium's `FrameStackObservation` get a silent fallback to `FlattenExtractor` (no CNN), with no error, which is surprising and hard to debug. Documenting the recommended `VecFrameStack` alternative prevents this pitfall.

- [x] I have raised an issue to propose this change ([required](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) for new features and bug fixes) — issue #2090, triaged by a maintainer (@araffin), who proposed this documentation approach.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (update in the documentation)

## Checklist

- [x] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the changelog accordingly (`docs/misc/changelog.md`) (**required**).
- [x] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*). — N/A: documentation-only change, no code modified.
- [x] I have updated the documentation accordingly.
- [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary) — N/A.
- [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary) — N/A.
- [ ] I have reformatted the code using `make format` (**required**) — N/A: no Python code changed (docs only).
- [ ] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**) — N/A: no Python code changed (docs only).
- [ ] I have ensured `make pytest` and `make type` both pass. (**required**) — N/A: no Python code changed (docs only).
- [x] I have checked that the documentation builds using `make doc` (**required**) — build succeeded, no warnings/errors; the warning admonition renders on the custom-env page.

---

**LLM/code-assistant disclosure** (per CONTRIBUTING.md): this documentation change was prepared with the assistance of Claude, an LLM code assistant. The approach — documenting the pitfall and recommending `VecFrameStack` rather than altering `is_image_space` — was proposed by maintainer @araffin in #2090. I have personally reviewed and verified the change.
