### PR TITLE
Fix VecEnv sub-env seed overlap for adjacent base seeds

### DIFF
--- a/stable_baselines3/common/env_util.py
+++ b/stable_baselines3/common/env_util.py
@@ -3,6 +3,7 @@ from collections.abc import Callable
 from typing import Any
 
 import gymnasium as gym
+import numpy as np
 
 from stable_baselines3.common.atari_wrappers import AtariWrapper
 from stable_baselines3.common.monitor import Monitor
@@ -80,6 +81,14 @@ def make_vec_env(
     wrapper_kwargs = wrapper_kwargs or {}
     assert vec_env_kwargs is not None  # for mypy
 
+    # Independent per-rank action-space seeds (same SeedSequence idea as VecEnv.seed).
+    action_seeds: list[int] | None = None
+    if seed is not None:
+        n_action_seeds = n_envs + start_index
+        action_seeds = [
+            int(s) for s in np.random.SeedSequence(int(seed)).generate_state(n_action_seeds)
+        ]
+
     def make_env(rank: int) -> Callable[[], gym.Env]:
         def _init() -> gym.Env:
             # For type checker:
@@ -100,10 +109,10 @@ def make_vec_env(
                 # Patch to support gym 0.21/0.26 and gymnasium
                 env = _patch_env(env)
 
-            if seed is not None:
+            if action_seeds is not None:
                 # Note: here we only seed the action space
-                # We will seed the env at the next reset
-                env.action_space.seed(seed + rank)
+                # We will seed the env at the next reset (issue #2268).
+                env.action_space.seed(action_seeds[rank])
             # Wrap the env in a Monitor wrapper
             # to have additional training information
             monitor_path = os.path.join(monitor_dir, str(rank)) if monitor_dir is not None else None

--- a/stable_baselines3/common/vec_env/base_vec_env.py
+++ b/stable_baselines3/common/vec_env/base_vec_env.py
@@ -292,7 +292,10 @@ class VecEnv(ABC):
     def seed(self, seed: int | None = None) -> Sequence[None | int]:
         """
         Sets the random seeds for all environments, based on a given seed.
-        Each individual environment will still get its own seed, by incrementing the given seed.
+        Each individual environment will still get its own seed, derived via
+        ``np.random.SeedSequence`` so adjacent base seeds do not share sub-env streams
+        (see issue #2268). Using ``seed + i`` caused runs with base seeds ``k`` and
+        ``k+1`` to reuse most of the same per-env seeds.
         WARNING: since gym 0.26, those seeds will only be passed to the environment
         at the next reset.
 
@@ -305,7 +308,9 @@ class VecEnv(ABC):
             # we still populate the seed variable when no argument is passed
             seed = int(np.random.randint(0, np.iinfo(np.uint32).max, dtype=np.uint32))
 
-        self._seeds = [seed + idx for idx in range(self.num_envs)]
+        # Spawn independent child seeds; values fit in uint32 for env RNG APIs.
+        child_states = np.random.SeedSequence(int(seed)).generate_state(self.num_envs)
+        self._seeds = [int(s) for s in child_states]
         return self._seeds
 
     def set_options(self, options: list[dict] | dict | None = None) -> None:

--- a/tests/test_vec_envs.py
+++ b/tests/test_vec_envs.py
@@ -589,6 +589,28 @@ def test_vec_seeding(vec_env_class):
 
 
 @pytest.mark.parametrize("vec_env_class", VEC_ENV_CLASSES)
+def test_vec_seed_no_adjacent_base_seed_overlap(vec_env_class):
+    """Adjacent base seeds must not share sub-env seeds (issue #2268).
+
+    The old ``seed + i`` scheme made ``seed(0)`` with 4 envs use {0,1,2,3} and
+    ``seed(1)`` use {1,2,3,4}, so three of four streams were identical.
+    """
+    n_envs = 4
+    vec_a = vec_env_class([lambda: CustomGymEnv(spaces.Box(low=np.zeros(2), high=np.ones(2))) for _ in range(n_envs)])
+    vec_b = vec_env_class([lambda: CustomGymEnv(spaces.Box(low=np.zeros(2), high=np.ones(2))) for _ in range(n_envs)])
+    seeds_a = vec_a.seed(0)
+    seeds_b = vec_b.seed(1)
+    assert seeds_a is not None and seeds_b is not None
+    assert len(set(seeds_a)) == n_envs
+    assert len(set(seeds_b)) == n_envs
+    assert set(seeds_a).isdisjoint(set(seeds_b))
+    # Same base seed is still deterministic / reproducible.
+    assert vec_a.seed(0) == seeds_a
+    vec_a.close()
+    vec_b.close()
+
+
+@pytest.mark.parametrize("vec_env_class", VEC_ENV_CLASSES)
 def test_render(vec_env_class):
     # Skip if no X-Server
     if not os.environ.get("DISPLAY"):


### PR DESCRIPTION
## Description

`VecEnv.seed(seed)` used `seed + i` for sub-environments. Adjacent base seeds therefore shared most sub-env streams (e.g. `n_envs=4`: seed `0` → `{0,1,2,3}`, seed `1` → `{1,2,3,4}`).

This derives independent child seeds with `np.random.SeedSequence(seed).generate_state(n_envs)` and applies the same idea when seeding action spaces in `make_vec_env`.

## Related Issue

Fixes #2268

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md)
- [x] I have checked that there is no similar [issue](https://github.com/DLR-RM/stable-baselines3/issues) or [PR](https://github.com/DLR-RM/stable-baselines3/pulls)
- [x] I have mentioned the related issue
- [x] I have added tests that prove my fix is effective