### PR TITLE
Add opt-in independent_seeds to VecEnv.seed and make_vec_env (#2268)

### DIFF
--- a/docs/misc/changelog.md
+++ b/docs/misc/changelog.md
@@ -8,6 +8,9 @@
 
 ### New Features:
 
+- Added an opt-in ``independent_seeds`` argument to ``VecEnv.seed()`` and ``make_vec_env()`` to derive
+  statistically independent, non-overlapping sub-environment seeds via ``np.random.SeedSequence`` (see #2268)
+
 ### Bug Fixes:
 
 ### [SB3-Contrib]
@@ -17,6 +20,11 @@
 ### [SBX] (SB3 + Jax)
 
 ### Deprecations:
+
+- The default ``VecEnv`` seeding scheme (``seed + i`` per sub-environment) now warns when used with more than
+  one env, as adjacent base seeds share most of their RNG streams; pass ``independent_seeds=True`` for independent
+  runs or ``independent_seeds=False`` to keep the legacy behavior. The default will switch to independent seeding
+  in a future release (see #2268)
 
 ### Others:
 

--- a/stable_baselines3/common/env_util.py
+++ b/stable_baselines3/common/env_util.py
@@ -7,6 +7,7 @@ import gymnasium as gym
 from stable_baselines3.common.atari_wrappers import AtariWrapper
 from stable_baselines3.common.monitor import Monitor
 from stable_baselines3.common.vec_env import DummyVecEnv, SubprocVecEnv, VecEnv
+from stable_baselines3.common.vec_env.base_vec_env import get_env_seeds
 from stable_baselines3.common.vec_env.patch_gym import _patch_env
 
 
@@ -42,6 +43,7 @@ def make_vec_env(
     n_envs: int = 1,
     seed: int | None = None,
     start_index: int = 0,
+    independent_seeds: bool | None = None,
     monitor_dir: str | None = None,
     wrapper_class: Callable[[gym.Env], gym.Env] | None = None,
     env_kwargs: dict[str, Any] | None = None,
@@ -59,6 +61,12 @@ def make_vec_env(
     :param n_envs: the number of environments you wish to have in parallel
     :param seed: the initial seed for the random number generator
     :param start_index: start rank index
+    :param independent_seeds: How to derive the per-environment seeds from ``seed``.
+        ``None`` (default) and ``False`` use the legacy ``seed + i`` scheme, so runs with
+        adjacent base seeds share most of their sub-environment RNG streams; ``True`` derives
+        independent, non-overlapping seeds via ``np.random.SeedSequence``. The default will
+        switch to ``True`` in a future release. See
+        https://github.com/DLR-RM/stable-baselines3/issues/2268
     :param monitor_dir: Path to a folder where the monitor files will be saved.
         If None, no file will be written, however, the env will still be wrapped
         in a Monitor wrapper to provide additional information about training.
@@ -79,6 +87,10 @@ def make_vec_env(
     monitor_kwargs = monitor_kwargs or {}
     wrapper_kwargs = wrapper_kwargs or {}
     assert vec_env_kwargs is not None  # for mypy
+
+    # When using independent seeds, precompute the per-env seeds so that the action spaces
+    # are seeded consistently with the observation/env RNG seeding done by ``VecEnv.seed`` below.
+    action_space_seeds = get_env_seeds(seed, n_envs, independent_seeds) if (seed is not None and independent_seeds) else None
 
     def make_env(rank: int) -> Callable[[], gym.Env]:
         def _init() -> gym.Env:
@@ -103,7 +115,11 @@ def make_vec_env(
             if seed is not None:
                 # Note: here we only seed the action space
                 # We will seed the env at the next reset
-                env.action_space.seed(seed + rank)
+                if independent_seeds:
+                    assert action_space_seeds is not None  # for mypy
+                    env.action_space.seed(action_space_seeds[rank - start_index])
+                else:
+                    env.action_space.seed(seed + rank)
             # Wrap the env in a Monitor wrapper
             # to have additional training information
             monitor_path = os.path.join(monitor_dir, str(rank)) if monitor_dir is not None else None
@@ -125,7 +141,7 @@ def make_vec_env(
 
     vec_env = vec_env_cls([make_env(i + start_index) for i in range(n_envs)], **vec_env_kwargs)
     # Prepare the seeds for the first reset
-    vec_env.seed(seed)
+    vec_env.seed(seed, independent_seeds=independent_seeds)
     return vec_env
 
 

--- a/stable_baselines3/common/vec_env/base_vec_env.py
+++ b/stable_baselines3/common/vec_env/base_vec_env.py
@@ -21,6 +21,28 @@ VecEnvObs = Union[np.ndarray, dict[str, np.ndarray], tuple[np.ndarray, ...]]  # 
 VecEnvStepReturn = tuple[VecEnvObs, np.ndarray, np.ndarray, list[dict]]
 
 
+def get_env_seeds(seed: int, num_envs: int, independent_seeds: bool | None = None) -> list[int | None]:
+    """
+    Derive one seed per sub-environment from a single base seed.
+
+    :param seed: The base seed.
+    :param num_envs: The number of sub-environments.
+    :param independent_seeds: How to derive the per-env seeds from ``seed``:
+
+        - ``True``: derive statistically independent, non-overlapping seeds using
+          ``np.random.SeedSequence`` so that adjacent base seeds (e.g. ``0`` and ``1``)
+          no longer share sub-environment RNG streams.
+        - ``False``: use the legacy ``seed + i`` scheme.
+        - ``None`` (current default): behaves like ``False`` for now, but the default
+          will switch to independent seeding in a future release. See
+          https://github.com/DLR-RM/stable-baselines3/issues/2268
+    :return: A list of ``num_envs`` integer seeds.
+    """
+    if independent_seeds:
+        return [int(child_seed) for child_seed in np.random.SeedSequence(seed).generate_state(num_envs)]
+    return [seed + idx for idx in range(num_envs)]
+
+
 def tile_images(images_nhwc: Sequence[np.ndarray]) -> np.ndarray:  # pragma: no cover
     """
     Tile N images into one big PxQ image
@@ -289,7 +311,7 @@ class VecEnv(ABC):
             self.env_method("render")
         return None
 
-    def seed(self, seed: int | None = None) -> Sequence[None | int]:
+    def seed(self, seed: int | None = None, *, independent_seeds: bool | None = None) -> Sequence[int | None]:
         """
         Sets the random seeds for all environments, based on a given seed.
         Each individual environment will still get its own seed, by incrementing the given seed.
@@ -297,6 +319,13 @@ class VecEnv(ABC):
         at the next reset.
 
         :param seed: The random seed. May be None for completely random seeding.
+        :param independent_seeds: How to derive the per-env seeds from ``seed``.
+            With the legacy scheme, sub-environment ``i`` is seeded with ``seed + i``, so runs
+            with adjacent base seeds (e.g. ``0`` and ``1``) share most of their RNG streams.
+            Pass ``True`` to derive independent, non-overlapping seeds via ``np.random.SeedSequence``
+            (recommended for statistically independent runs), or ``False`` to keep the legacy
+            scheme and silence the warning. The default will switch to ``True`` in a future release.
+            See https://github.com/DLR-RM/stable-baselines3/issues/2268
         :return: Returns a list containing the seeds for each individual env.
             Note that all list elements may be None, if the env does not return anything when being seeded.
         """
@@ -304,8 +333,17 @@ class VecEnv(ABC):
             # To ensure that subprocesses have different seeds,
             # we still populate the seed variable when no argument is passed
             seed = int(np.random.randint(0, np.iinfo(np.uint32).max, dtype=np.uint32))
+        elif independent_seeds is None and self.num_envs > 1:
+            warnings.warn(
+                "The default VecEnv seeding scheme assigns `seed + i` to sub-environment `i`, so runs "
+                "with adjacent base seeds (e.g. 0 and 1) share most of their sub-environment RNG streams. "
+                "Pass `independent_seeds=True` to derive independent, non-overlapping seeds, or "
+                "`independent_seeds=False` to keep the current behavior and silence this warning. "
+                "The default will switch to independent seeding in a future release. "
+                "See https://github.com/DLR-RM/stable-baselines3/issues/2268"
+            )
 
-        self._seeds = [seed + idx for idx in range(self.num_envs)]
+        self._seeds = get_env_seeds(seed, self.num_envs, independent_seeds)
         return self._seeds
 
     def set_options(self, options: list[dict] | dict | None = None) -> None:
@@ -392,8 +430,8 @@ class VecEnvWrapper(VecEnv):
     def step_wait(self) -> VecEnvStepReturn:
         pass
 
-    def seed(self, seed: int | None = None) -> Sequence[None | int]:
-        return self.venv.seed(seed)
+    def seed(self, seed: int | None = None, *, independent_seeds: bool | None = None) -> Sequence[int | None]:
+        return self.venv.seed(seed, independent_seeds=independent_seeds)
 
     def set_options(self, options: list[dict] | dict | None = None) -> None:
         return self.venv.set_options(options)

--- a/tests/test_vec_envs.py
+++ b/tests/test_vec_envs.py
@@ -14,6 +14,7 @@ from stable_baselines3 import PPO
 from stable_baselines3.common.env_util import make_vec_env
 from stable_baselines3.common.monitor import Monitor
 from stable_baselines3.common.vec_env import DummyVecEnv, SubprocVecEnv, VecFrameStack, VecNormalize, VecVideoRecorder
+from stable_baselines3.common.vec_env.base_vec_env import get_env_seeds
 
 try:
     import moviepy  # noqa: F401
@@ -586,6 +587,144 @@ def test_vec_seeding(vec_env_class):
         assert not np.allclose(rewards[1], rewards[2])
 
         vec_env.close()
+
+
+def _box_env():
+    return CustomGymEnv(spaces.Box(low=np.zeros(2), high=np.ones(2)))
+
+
+@pytest.mark.parametrize("independent_seeds", [None, False])
+def test_get_env_seeds_legacy(independent_seeds):
+    # None (current default) and False both use the legacy `seed + i` scheme
+    assert get_env_seeds(0, 4, independent_seeds=independent_seeds) == [0, 1, 2, 3]
+    assert get_env_seeds(10, 1, independent_seeds=independent_seeds) == [10]
+    # Adjacent base seeds overlap on 3 of the 4 sub-envs under the legacy scheme (the bug in #2268)
+    assert get_env_seeds(0, 4, independent_seeds=independent_seeds)[1:] == get_env_seeds(1, 4)[:3]
+
+
+def test_get_env_seeds_independent():
+    seeds_0 = get_env_seeds(0, 4, independent_seeds=True)
+    seeds_1 = get_env_seeds(1, 4, independent_seeds=True)
+    # Unique within a run, disjoint across adjacent base seeds
+    assert len(seeds_0) == 4
+    assert len(set(seeds_0)) == 4
+    assert set(seeds_0).isdisjoint(seeds_1)
+    # Reproducible, distinct from the legacy mapping, and plain python ints (clean downstream seeding)
+    assert get_env_seeds(0, 4, independent_seeds=True) == seeds_0
+    assert seeds_0 != get_env_seeds(0, 4)
+    assert all(isinstance(seed, int) for seed in seeds_0)
+
+
+@pytest.mark.parametrize("vec_env_class", VEC_ENV_CLASSES)
+def test_vec_env_seed_modes(vec_env_class):
+    n_envs = 4
+    vec_env = vec_env_class([_box_env] * n_envs)
+    # Explicit legacy mode stores `seed + i`
+    assert list(vec_env.seed(0, independent_seeds=False)) == [0, 1, 2, 3]
+    # Independent mode stores non-overlapping, reproducible seeds matching the helper
+    seeds = list(vec_env.seed(0, independent_seeds=True))
+    assert seeds == get_env_seeds(0, n_envs, independent_seeds=True)
+    assert list(vec_env.seed(0, independent_seeds=True)) == seeds
+    # Random seeding (seed=None) still returns one seed per env
+    assert len(list(vec_env.seed())) == n_envs
+    vec_env.close()
+
+
+def test_vec_env_seed_warning_behavior():
+    vec_env = DummyVecEnv([_box_env, _box_env])
+    # Unset default with more than one sub-env warns, and the message is actionable
+    with pytest.warns(UserWarning, match="independent_seeds=True") as record:
+        vec_env.seed(0)
+    assert "2268" in str(record[0].message)
+
+    # An explicit choice (either way) and random seeding are silent
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        vec_env.seed(0, independent_seeds=False)
+        vec_env.seed(0, independent_seeds=True)
+        vec_env.seed()
+    vec_env.close()
+
+    # A single sub-env cannot overlap, so the default never warns
+    single_env = DummyVecEnv([_box_env])
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        single_env.seed(0)
+    single_env.close()
+
+
+def test_vec_env_wrapper_seed_passthrough():
+    vec_env = DummyVecEnv([_box_env, _box_env, _box_env])
+    wrapped = VecNormalize(vec_env)
+    # The flag is forwarded to the wrapped env: independent mode is silent and matches the helper
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        seeds = list(wrapped.seed(0, independent_seeds=True))
+    assert seeds == get_env_seeds(0, 3, independent_seeds=True)
+    assert list(vec_env.seed(0, independent_seeds=True)) == seeds
+    # The default path still warns through the wrapper
+    with pytest.warns(UserWarning, match="independent_seeds"):
+        wrapped.seed(0)
+    wrapped.close()
+
+
+@pytest.mark.parametrize("independent_seeds", [False, True])
+def test_make_vec_env_seed_overlap(independent_seeds):
+    n_envs = 4
+    reset_obs = {
+        base: make_vec_env("Pendulum-v1", n_envs=n_envs, seed=base, independent_seeds=independent_seeds).reset()
+        for base in (0, 1)
+    }
+    # Under the legacy scheme sub-envs 1..3 of the seed=0 run reuse the streams of sub-envs 0..2
+    # of the seed=1 run; the independent scheme breaks that overlap.
+    overlap = bool(np.allclose(reset_obs[0][1:], reset_obs[1][:3]))
+    assert overlap != independent_seeds
+    # Same seed + mode is reproducible either way
+    again = make_vec_env("Pendulum-v1", n_envs=n_envs, seed=0, independent_seeds=independent_seeds).reset()
+    assert np.allclose(again, reset_obs[0])
+
+
+@pytest.mark.parametrize("independent_seeds", [False, True])
+def test_make_vec_env_action_space_seed_consistency(independent_seeds):
+    # The action-space seeding in make_vec_env must move together with VecEnv.seed's env seeding,
+    # otherwise one site could be fixed while the other stays correlated (regression guard).
+    n_envs = 4
+
+    def action_space_samples(base):
+        vec_env = make_vec_env("Pendulum-v1", n_envs=n_envs, seed=base, independent_seeds=independent_seeds)
+        return [env.action_space.sample() for env in vec_env.envs]
+
+    overlap = bool(np.allclose(action_space_samples(0)[1:], action_space_samples(1)[:3]))
+    assert overlap != independent_seeds
+
+
+def test_make_vec_env_independent_seeds_with_start_index():
+    # start_index shifts the legacy action-space seeds (seed + rank); the independent path must
+    # index its precomputed per-env seeds by `rank - start_index` (guards the offset arithmetic).
+    n_envs = 3
+    vec_env = make_vec_env("Pendulum-v1", n_envs=n_envs, seed=0, start_index=5, independent_seeds=True)
+    # Env RNG seeds come from the helper regardless of start_index
+    assert list(vec_env._seeds) == get_env_seeds(0, n_envs, independent_seeds=True)
+    shifted_samples = [env.action_space.sample() for env in vec_env.envs]
+    # The action-space seeds must not depend on start_index (indexing is offset-corrected)
+    baseline = make_vec_env("Pendulum-v1", n_envs=n_envs, seed=0, start_index=0, independent_seeds=True)
+    baseline_samples = [env.action_space.sample() for env in baseline.envs]
+    assert np.allclose(shifted_samples, baseline_samples)
+
+
+def test_make_vec_env_default_warns_once():
+    # The default path emits exactly one heads-up (only via VecEnv.seed, not duplicated per env)
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
+        make_vec_env("Pendulum-v1", n_envs=3, seed=0)
+    assert len([w for w in record if "independent_seeds" in str(w.message)]) == 1
+
+    # A single env, an explicit choice, or random seeding must not emit our warning
+    for kwargs in (dict(n_envs=1, seed=0), dict(n_envs=3, seed=0, independent_seeds=False), dict(n_envs=3)):
+        with warnings.catch_warnings(record=True) as record:
+            warnings.simplefilter("always")
+            make_vec_env("Pendulum-v1", **kwargs)
+        assert not any("independent_seeds" in str(w.message) for w in record)
 
 
 @pytest.mark.parametrize("vec_env_class", VEC_ENV_CLASSES)


### PR DESCRIPTION
## Description

Adds an **opt-in** `independent_seeds` argument to `VecEnv.seed()` and `make_vec_env()` that derives statistically independent, non-overlapping per-sub-environment seeds via `np.random.SeedSequence`, instead of the legacy `seed + i` scheme.

The default behavior is **unchanged** (`seed + i`), so nothing about existing reproducibility changes on upgrade. When more than one sub-env is used and no choice is made, a warning now points out the overlap and announces that the default will switch to independent seeding in a future release.

- `independent_seeds=True` → non-overlapping seeds; adjacent base seeds (e.g. `0` and `1`) no longer share sub-env RNG streams.
- `independent_seeds=False` → legacy `seed + i`, explicitly pinned (silences the warning; the way to reproduce older runs later).
- unset (default) → legacy `seed + i` + a one-time heads-up (only when `num_envs > 1`).

The flag threads through **both** places the `seed + i` scheme lives today so they stay consistent: `VecEnv.seed` (env/observation RNG) and the `action_space.seed(seed + rank)` inside `make_vec_env`.

## Motivation and Context

Under `seed + i`, runs with adjacent base seeds share most of their sub-environment RNG streams (with `n_envs=4`, `seed=0` gives `{0,1,2,3}` and `seed=1` gives `{1,2,3,4}` — 3 of 4 identical). Sweeping `seed=0..N` for "independent" runs therefore yields correlated runs, quietly biasing variance / significance statistics.

This is the two-release migration proposed and discussed in the issue: give people an opt-in fix now with zero disruption, announce the change, and flip the default in a later minor release with `independent_seeds=False` remaining available forever to reproduce old runs bit-for-bit.

Towards #2268 (maintainer invited a PR there).

- [x] I have raised an issue to propose this change ([required](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) for new features and bug fixes)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (update in the documentation)

## Checklist
- [x] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the changelog accordingly (`docs/misc/changelog.md`) (**required**).
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
- [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary)
- [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary)
- [x] I have reformatted the code using `make format` (**required**)
- [x] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [x] I have ensured `make pytest` and `make type` both pass. (**required**)
- [x] I have checked that the documentation builds using `make doc` (**required**)

<sub>Disclosure (per CONTRIBUTING): implemented with AI assistance (Claude), human-directed — the design (opt-in over a default change, the tri-state semantics, naming, and the two-release migration) was decided by me; @araffin invited a PR in #2268. Opening as a draft to confirm direction before it's marked ready.</sub>
