### PR TITLE
Fix Docker build: add --system to uv pip uninstall opencv-python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN cd ${CODE_DIR}/stable-baselines3 && \
     uv pip install --system torch --default-index ${PYTORCH_DEPS} && \
     uv pip install --system -e .[extra,tests,docs] && \
     # Use headless version for docker
-    uv pip uninstall opencv-python && \
+    uv pip uninstall --system opencv-python && \
     uv pip install --system opencv-python-headless && \
     pip cache purge && \
     uv cache clean

--- a/docs/misc/changelog.md
+++ b/docs/misc/changelog.md
@@ -25,6 +25,7 @@
 - Fixed mypy error in test_vec_envs.py by wrapping `itertools.product` with `list()`
 - Improved tests coverage for RMSpropTFLike optimizer (invalid params, centered/momentum/weight_decay branches, pickle roundtrip)
 - Improved test coverage for `save_util.py`: added tests for `BadZipFile` error handling in `load_from_zip_file` and `IsADirectoryError`/`FileNotFoundError` handling in `open_path`
+- Fixed Docker build by adding the missing `--system` flag to `uv pip uninstall opencv-python` (required by recent `uv`)
 
 ### Documentation:
 

--- a/stable_baselines3/common/envs/__init__.py
+++ b/stable_baselines3/common/envs/__init__.py
@@ -16,5 +16,4 @@ __all__ = [
     "IdentityEnvMultiBinary",
     "IdentityEnvMultiDiscrete",
     "SimpleMultiObsEnv",
-    "SimpleMultiObsEnv",
 ]

--- a/stable_baselines3/common/vec_env/base_vec_env.py
+++ b/stable_baselines3/common/vec_env/base_vec_env.py
@@ -289,7 +289,7 @@ class VecEnv(ABC):
             self.env_method("render")
         return None
 
-    def seed(self, seed: int | None = None) -> Sequence[None | int]:
+    def seed(self, seed: int | None = None) -> Sequence[int | None]:
         """
         Sets the random seeds for all environments, based on a given seed.
         Each individual environment will still get its own seed, by incrementing the given seed.
@@ -392,7 +392,7 @@ class VecEnvWrapper(VecEnv):
     def step_wait(self) -> VecEnvStepReturn:
         pass
 
-    def seed(self, seed: int | None = None) -> Sequence[None | int]:
+    def seed(self, seed: int | None = None) -> Sequence[int | None]:
         return self.venv.seed(seed)
 
     def set_options(self, options: list[dict] | dict | None = None) -> None:

--- a/stable_baselines3/ppo/ppo.py
+++ b/stable_baselines3/ppo/ppo.py
@@ -88,7 +88,7 @@ class PPO(OnPolicyAlgorithm):
         gamma: float = 0.99,
         gae_lambda: float = 0.95,
         clip_range: float | Schedule = 0.2,
-        clip_range_vf: None | float | Schedule = None,
+        clip_range_vf: float | Schedule | None = None,
         normalize_advantage: bool = True,
         ent_coef: float = 0.0,
         vf_coef: float = 0.5,


### PR DESCRIPTION
## Description

Adds the missing `--system` flag to the `uv pip uninstall opencv-python` step in the `Dockerfile`.

Every other `uv pip` call in that `RUN` already passes `--system`, but the `uninstall` does not. Recent `uv` versions require `--system` for `uninstall` too when operating outside a virtual environment, so the Docker build now fails at that step:

```
error: No virtual environment found; run `uv venv` to create an environment,
or pass `--system` to install into a non-virtual environment
```

This breaks `make docker-cpu` / `make docker-gpu` and the docs image for anyone building with a current `uv`. The `.[extra,tests,docs]` install itself succeeds — only the subsequent `uninstall` fails.

## Motivation and Context

The Docker image build is currently broken with recent `uv`. One-line fix, verified by building the image end-to-end (`docker build .` succeeds; `import stable_baselines3` and the vec-env tests run in the resulting image).

<!-- No separate issue opened: this is a trivial, self-evident build-breakage fix. Happy to file one if preferred. -->

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist
- [x] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the changelog accordingly (`docs/misc/changelog.md`) (**required**).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [x] I have reformatted the code using `make format` (**required**)
- [x] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [x] I have ensured `make pytest` and `make type` both pass. (**required**)
- [ ] I have checked that the documentation builds using `make doc` (**required**)

<sub>Disclosure (per CONTRIBUTING): found and fixed with AI assistance while building the dev image; the diagnosis (missing `--system` on the `uninstall`) was verified by reproducing the failing build and rebuilding green.</sub>
