### PR TITLE
Print the noise errors as sentences, not as tuples

### DIFF
--- a/stable_baselines3/common/noise.py
+++ b/stable_baselines3/common/noise.py
@@ -147,9 +147,9 @@ class VectorizedActionNoise(ActionNoise):
     @base_noise.setter
     def base_noise(self, base_noise: ActionNoise) -> None:
         if base_noise is None:
-            raise ValueError("Expected base_noise to be an instance of ActionNoise, not None", ActionNoise)
+            raise ValueError("Expected base_noise to be an instance of ActionNoise, not None")
         if not isinstance(base_noise, ActionNoise):
-            raise TypeError("Expected base_noise to be an instance of type ActionNoise", ActionNoise)
+            raise TypeError(f"Expected base_noise to be an instance of ActionNoise, not {type(base_noise).__name__}")
         self._base_noise = base_noise
 
     @property
@@ -165,7 +165,8 @@ class VectorizedActionNoise(ActionNoise):
 
         if len(different_types):
             raise ValueError(
-                f"Noise instances at indices {different_types} don't match the type of base_noise", type(self.base_noise)
+                f"Noise instances at indices {different_types} don't match the type of base_noise, "
+                f"{type(self.base_noise).__name__}"
             )
 
         self._noises = noises

--- a/tests/test_noise.py
+++ b/tests/test_noise.py
@@ -1,0 +1,34 @@
+import numpy as np
+import pytest
+
+from stable_baselines3.common.noise import (
+    NormalActionNoise,
+    OrnsteinUhlenbeckActionNoise,
+    VectorizedActionNoise,
+)
+
+
+def test_vectorized_noise_error_messages():
+    """The errors should read as a sentence rather than as a tuple.
+
+    Each of these raises passed a class object as a second positional argument,
+    so ``str(exception)`` rendered the whole tuple — quotes and angle brackets
+    included — instead of the sentence that was written.
+    """
+    base = OrnsteinUhlenbeckActionNoise(np.zeros(2), np.ones(2))
+
+    with pytest.raises(ValueError) as excinfo:
+        VectorizedActionNoise(None, 2)
+    assert len(excinfo.value.args) == 1
+    assert str(excinfo.value) == "Expected base_noise to be an instance of ActionNoise, not None"
+
+    with pytest.raises(TypeError) as excinfo:
+        VectorizedActionNoise(12, 2)
+    assert len(excinfo.value.args) == 1
+    assert str(excinfo.value).endswith("not int")
+
+    vec = VectorizedActionNoise(base, 2)
+    with pytest.raises(ValueError) as excinfo:
+        vec.noises = [base, NormalActionNoise(np.zeros(2), np.ones(2))]
+    assert len(excinfo.value.args) == 1
+    assert str(excinfo.value).endswith("OrnsteinUhlenbeckActionNoise")


### PR DESCRIPTION
## Description

Three raises in `VectorizedActionNoise` pass a class object as a second
positional argument, so `str(exception)` renders the whole tuple rather than
the sentence that was written:

```python
>>> VectorizedActionNoise(None, 2)
ValueError: ('Expected base_noise to be an instance of ActionNoise, not None', <class 'stable_baselines3.common.noise.ActionNoise'>)

>>> VectorizedActionNoise(12, 2)
TypeError: ('Expected base_noise to be an instance of type ActionNoise', <class 'stable_baselines3.common.noise.ActionNoise'>)

>>> vec.noises = [base, something_else]
ValueError: ("Noise instances at indices [1] don't match the type of base_noise", <class '...NormalActionNoise'>)
```

The class object adds nothing the sentence does not already name. After:

```
ValueError: Expected base_noise to be an instance of ActionNoise, not None
TypeError: Expected base_noise to be an instance of ActionNoise, not int
ValueError: Noise instances at indices [1] don't match the type of base_noise, OrnsteinUhlenbeckActionNoise
```

Where the concrete type is worth having it now goes into the message, so the
caller is told what was passed rather than what was expected.

## Scope

An AST pass over `stable_baselines3/` finds fifteen raises with more than one
positional argument. Twelve construct `FormatUnsupportedError` in `logger.py`,
whose `__init__` takes `(unsupported_formats, value_description)` by design and
builds its own message — those are correct and untouched. The three in
`noise.py` are the only built-in exceptions given a second argument.

## Tests

New `tests/test_noise.py`: each of the three raises carries a single argument
and reads as a sentence. `len(exception.args) == 1` is the assertion that fails
on `master`; the test passes here.

I put it in a new file rather than next to the existing `test_vec_noise` in
`tests/test_utils.py` because that module imports `ale_py` at module scope,
which I could not install in this environment — so a test added there would
have gone in unverified. Happy to move it if you would rather keep noise tests
together.

`ruff check`, `ruff check --select I`, `black --check` and `mypy` are clean on
both files. No existing test asserts on these messages.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
