### PR TITLE
Fix missing header when Monitor appends to a new file

### DIFF
--- a/docs/misc/changelog.md
+++ b/docs/misc/changelog.md
@@ -9,6 +9,7 @@
 ### New Features:
 
 ### Bug Fixes:
+- Fixed `Monitor`/`ResultsWriter` not writing the CSV header when `override_existing=False` and the file does not exist yet, which made `load_results` fail on the produced file (@yurekami)
 
 ### [SB3-Contrib]
 

--- a/stable_baselines3/common/monitor.py
+++ b/stable_baselines3/common/monitor.py
@@ -196,7 +196,8 @@ class ResultsWriter:
         # Prevent newline issue on Windows, see GH issue #692
         self.file_handler = open(filename, f"{mode}t", newline="\n")
         self.logger = csv.DictWriter(self.file_handler, fieldnames=("r", "l", "t", *extra_keys))
-        if override_existing:
+        # Write the header when overriding, or when appending to a new/empty file (nothing to append to)
+        if override_existing or os.path.getsize(filename) == 0:
             self.file_handler.write(f"#{json.dumps(header)}\n")
             self.logger.writeheader()
 

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -172,3 +172,28 @@ def test_monitor_error_cases():
     with pytest.raises(RuntimeError, match="Tried to step environment that needs reset"):
         monitor_env3 = Monitor(env3)
         monitor_env3.step(monitor_env3.action_space.sample())
+
+
+def test_monitor_append_new_file(tmp_path):
+    """
+    Test that the header is written when appending (``override_existing=False``)
+    to a monitor file that does not exist yet.
+    """
+    monitor_file = os.path.join(str(tmp_path), f"stable_baselines-test-{uuid.uuid4()}.monitor.csv")
+    assert not os.path.exists(monitor_file)
+    # Run one episode twice, appending to the same file both times
+    for _ in range(2):
+        monitor_env = Monitor(gym.make("CartPole-v1"), monitor_file, override_existing=False)
+        monitor_env.reset(seed=0)
+        terminated = truncated = False
+        while not (terminated or truncated):
+            _, _, terminated, truncated, _ = monitor_env.step(monitor_env.action_space.sample())
+        monitor_env.close()
+
+    with open(monitor_file) as file_handler:
+        lines = file_handler.read().splitlines()
+    # The header (json + column names) must be written only once, followed by one row per episode
+    assert lines[0].startswith("#")
+    assert lines[1] == "r,l,t"
+    assert len(lines) == 4
+    assert len(load_results(str(tmp_path))) == 2


### PR DESCRIPTION
## Description
`ResultsWriter` only wrote the `#{json header}` line and the CSV column names when `override_existing=True`. With `override_existing=False` and a `filename` that does not exist yet, the file was created in append mode without any header, so `load_results()` (and `results_plotter`) failed with an `AssertionError` on the produced `monitor.csv`.

The header is now written whenever the file is new or empty (nothing to append to). Appending to an existing, non-empty file still does not duplicate the header. Added a regression test and a changelog entry.

Minimal repro on master:
```python
env = Monitor(gym.make("CartPole-v1"), "logs/run.monitor.csv", override_existing=False)  # path does not exist yet
# ... run an episode, env.close() ...
load_results("logs")  # AssertionError: first line is a data row, not "#{...}"
```

Fixes #2282

## Motivation and Context
`override_existing=False` was added in #1037 for the use case in #1035 (re-running the same script after a job time limit). The first run of such a script necessarily hits the not-yet-existing-file path, so users following that pattern get an unreadable log from the first run onward. The existing test only covered appending to a file that had already been created with the default `override_existing=True`.

- [x] I have raised an issue to propose this change ([required](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) for new features and bug fixes)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist
- [x] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the changelog accordingly (`docs/misc/changelog.md`) (**required**).
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [ ] I have opened an associated PR on the [SB3-Contrib repository](https://github.com/Stable-Baselines-Team/stable-baselines3-contrib) (if necessary)
- [ ] I have opened an associated PR on the [RL-Zoo3 repository](https://github.com/DLR-RM/rl-baselines3-zoo) (if necessary)
- [x] I have reformatted the code using `make format` (**required**)
- [x] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [x] I have ensured `make pytest` and `make type` both pass. (**required**)
- [ ] I have checked that the documentation builds using `make doc` (**required**)

Test note: `tests/test_monitor.py::test_monitor_append_new_file` fails on master and passes here. On this Windows box `test_monitor` and `test_monitor_load_results` fail identically with and without the change (`PermissionError: [WinError 32]`, the file is still open when the test reads it); they are unaffected by this PR and pass on Linux CI.

Disclosure: a code assistant (Claude) was used while preparing this change, as required by the contribution guidelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011vZKTbRaDh8FuXSbVpQomD
